### PR TITLE
Make authorization interceptor go vet and golint compliant

### DIFF
--- a/mw/auth/interceptor.go
+++ b/mw/auth/interceptor.go
@@ -13,7 +13,9 @@ import (
 )
 
 var (
-	ErrInternal     = grpc.Errorf(codes.Internal, "unable to process request")
+	// ErrInternal indicates a server-side error occured during authorization
+	ErrInternal = grpc.Errorf(codes.Internal, "unable to process request")
+	// ErrUnauthorized indicates that a given request has been denied
 	ErrUnauthorized = grpc.Errorf(codes.PermissionDenied, "unauthorized")
 )
 

--- a/mw/auth/interceptor.go
+++ b/mw/auth/interceptor.go
@@ -49,7 +49,7 @@ func (d defaultBuilder) build(ctx context.Context) (pdp.Request, error) {
 		}
 		attributes = combineAttributes(attributes, attrs)
 	}
-	return pdp.Request{attributes}, nil
+	return pdp.Request{Attributes: attributes}, nil
 }
 
 // NewBuilder returns an instance of the default Builder that includes all of

--- a/mw/auth/interceptor_test.go
+++ b/mw/auth/interceptor_test.go
@@ -16,34 +16,34 @@ func TestAuthFunc(t *testing.T) {
 		expected   error
 	}{
 		{
-			Authorizer{"", NewBuilder(), NewHandler()},
-			func() pep.Client { return mockClient{} },
-			nil,
+			authorizer: Authorizer{"", NewBuilder(), NewHandler()},
+			factory:    func() pep.Client { return mockClient{} },
+			expected:   nil,
 		},
 		{
-			Authorizer{"", NewBuilder(), NewHandler()},
-			func() pep.Client { return mockClient{deny: true} },
-			ErrUnauthorized,
+			authorizer: Authorizer{"", NewBuilder(), NewHandler()},
+			factory:    func() pep.Client { return mockClient{deny: true} },
+			expected:   ErrUnauthorized,
 		},
 		{
-			Authorizer{"", NewBuilder(), NewHandler()},
-			func() pep.Client { return mockClient{errOnConnect: true} },
-			ErrInternal,
+			authorizer: Authorizer{"", NewBuilder(), NewHandler()},
+			factory:    func() pep.Client { return mockClient{errOnConnect: true} },
+			expected:   ErrInternal,
 		},
 		{
-			Authorizer{"", NewBuilder(), NewHandler()},
-			func() pep.Client { return mockClient{errOnValidate: true} },
-			ErrInternal,
+			authorizer: Authorizer{"", NewBuilder(), NewHandler()},
+			factory:    func() pep.Client { return mockClient{errOnValidate: true} },
+			expected:   ErrInternal,
 		},
 		{
-			Authorizer{"", mockBuilder{errOnBuild: true}, NewHandler()},
-			func() pep.Client { return mockClient{} },
-			ErrInternal,
+			authorizer: Authorizer{"", mockBuilder{errOnBuild: true}, NewHandler()},
+			factory:    func() pep.Client { return mockClient{} },
+			expected:   ErrInternal,
 		},
 		{
-			Authorizer{"", NewBuilder(), mockHandler{errOnHandle: true}},
-			func() pep.Client { return mockClient{} },
-			ErrInternal,
+			authorizer: Authorizer{"", NewBuilder(), mockHandler{errOnHandle: true}},
+			factory:    func() pep.Client { return mockClient{} },
+			expected:   ErrInternal,
 		},
 	}
 	for _, test := range authFuncTests {

--- a/mw/auth/jwt.go
+++ b/mw/auth/jwt.go
@@ -13,7 +13,7 @@ const (
 	// TODO: Field is tentatively called "AccountID" but will probably need to be
 	// changed. We don't know what the JWT will look like, so we're giving it our
 	// best guess for the time being.
-	MULTI_TENANCY_FIELD = "AccountID"
+	MultiTenancyField = "AccountID"
 )
 
 var (
@@ -39,7 +39,7 @@ func GetJWTField(ctx context.Context, field string, keyfunc jwt.Keyfunc) (string
 }
 
 func GetAccountID(ctx context.Context, keyfunc jwt.Keyfunc) (string, error) {
-	return GetJWTField(ctx, MULTI_TENANCY_FIELD, keyfunc)
+	return GetJWTField(ctx, MultiTenancyField, keyfunc)
 }
 
 // getToken parses the token into a jwt.Token type from the grpc metadata.

--- a/mw/auth/jwt.go
+++ b/mw/auth/jwt.go
@@ -13,6 +13,8 @@ const (
 	// TODO: Field is tentatively called "AccountID" but will probably need to be
 	// changed. We don't know what the JWT will look like, so we're giving it our
 	// best guess for the time being.
+
+	// MultiTenancyField the field name for a specific tenant
 	MultiTenancyField = "AccountID"
 )
 
@@ -22,6 +24,7 @@ var (
 	errInvalidAssertion = errors.New("unable to assert value as jwt.MapClaims")
 )
 
+// GetJWTField gets the JWT from a context and returns the specified field
 func GetJWTField(ctx context.Context, field string, keyfunc jwt.Keyfunc) (string, error) {
 	token, err := getToken(ctx, keyfunc)
 	if err != nil {
@@ -38,6 +41,7 @@ func GetJWTField(ctx context.Context, field string, keyfunc jwt.Keyfunc) (string
 	return fmt.Sprint(jwtField), nil
 }
 
+// GetAccountID gets the JWT from a context and returns the AccountID field
 func GetAccountID(ctx context.Context, keyfunc jwt.Keyfunc) (string, error) {
 	return GetJWTField(ctx, MultiTenancyField, keyfunc)
 }

--- a/mw/auth/jwt_test.go
+++ b/mw/auth/jwt_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	TEST_SECRET = "some-secret-123"
+	TestSecret = "some-secret-123"
 )
 
 func TestGetJWTField(t *testing.T) {
@@ -114,7 +114,7 @@ func makeToken(claims jwt.Claims, t *testing.T) string {
 	if err != nil {
 		t.Fatalf("Error when building token: %v", err)
 	}
-	signature, err := method.Sign(signingString, []byte(TEST_SECRET))
+	signature, err := method.Sign(signingString, []byte(TestSecret))
 	if err != nil {
 		t.Fatalf("Error when building token: %v", err)
 	}

--- a/mw/auth/jwt_test.go
+++ b/mw/auth/jwt_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 const (
+	// TestSecret dummy secret used for signing test JWTs
 	TestSecret = "some-secret-123"
 )
 

--- a/mw/auth/options.go
+++ b/mw/auth/options.go
@@ -29,7 +29,7 @@ func WithJWT(keyfunc jwt.Keyfunc) option {
 			return attributes, ErrInternal
 		}
 		for k, v := range claims {
-			attr := &pdp.Attribute{k, "string", fmt.Sprint(v)}
+			attr := &pdp.Attribute{Id: k, Type: "string", Value: fmt.Sprint(v)}
 			attributes = append(attributes, attr)
 		}
 		return attributes, nil
@@ -63,9 +63,9 @@ func WithRequest() option {
 		}
 		service = stripPackageName(service)
 		attributes := []*pdp.Attribute{
-			&pdp.Attribute{"operation", "string", method},
+			&pdp.Attribute{Id: "operation", Type: "string", Value: method},
 			// lowercase the service to match PARG naming conventions
-			&pdp.Attribute{"application", "string", strings.ToLower(service)},
+			&pdp.Attribute{Id: "application", Type: "string", Value: strings.ToLower(service)},
 		}
 		return attributes, nil
 	}

--- a/mw/auth/options_test.go
+++ b/mw/auth/options_test.go
@@ -24,11 +24,11 @@ func TestWithJWT(t *testing.T) {
 				"department": "engineering",
 			}, t),
 			expected: []*pdp.Attribute{
-				&pdp.Attribute{"department", "string", "engineering"},
-				&pdp.Attribute{"username", "string", "john"},
+				&pdp.Attribute{Id: "department", Type: "string", Value: "engineering"},
+				&pdp.Attribute{Id: "username", Type: "string", Value: "john"},
 			},
 			keyfunc: func(token *jwt.Token) (interface{}, error) {
-				return []byte(TEST_SECRET), nil
+				return []byte(TestSecret), nil
 			},
 			err: nil,
 		},
@@ -89,23 +89,23 @@ func TestWithCallback(t *testing.T) {
 		expected []*pdp.Attribute
 	}{
 		{
-			func(ctx context.Context) ([]*pdp.Attribute, error) {
+			callback: func(ctx context.Context) ([]*pdp.Attribute, error) {
 				attributes := []*pdp.Attribute{
-					&pdp.Attribute{"fruit", "string", "apple"},
-					&pdp.Attribute{"vegetable", "string", "carrot"},
+					&pdp.Attribute{Id: "fruit", Type: "string", Value: "apple"},
+					&pdp.Attribute{Id: "vegetable", Type: "string", Value: "carrot"},
 				}
 				return attributes, nil
 			},
-			[]*pdp.Attribute{
-				{"fruit", "string", "apple"},
-				{"vegetable", "string", "carrot"},
+			expected: []*pdp.Attribute{
+				{Id: "fruit", Type: "string", Value: "apple"},
+				{Id: "vegetable", Type: "string", Value: "carrot"},
 			},
 		},
 		{
-			func(ctx context.Context) ([]*pdp.Attribute, error) {
+			callback: func(ctx context.Context) ([]*pdp.Attribute, error) {
 				return []*pdp.Attribute{}, nil
 			},
-			[]*pdp.Attribute{},
+			expected: []*pdp.Attribute{},
 		},
 	}
 	for _, test := range callbackTests {
@@ -179,9 +179,9 @@ func TestStripPackageName(t *testing.T) {
 		fullname string
 		expected string
 	}{
-		{"ngp.api.toolkit.example.addressbook.AddressBook", "AddressBook"},
-		{"AddressBook", "AddressBook"},
-		{"", ""},
+		{fullname: "ngp.api.toolkit.example.addressbook.AddressBook", expected: "AddressBook"},
+		{fullname: "AddressBook", expected: "AddressBook"},
+		{fullname: "", expected: ""},
 	}
 	for _, test := range tests {
 		name := stripPackageName(test.fullname)
@@ -196,10 +196,10 @@ func hasMatchingAttributes(first, second []*pdp.Attribute) bool {
 	if len(first) != len(second) {
 		return false
 	}
-	for _, attr_first := range first {
+	for _, attrFirst := range first {
 		var hasAttribute bool
-		for _, attr_second := range second {
-			hasAttribute = hasAttribute || attr_first.String() == attr_second.String()
+		for _, attrSecond := range second {
+			hasAttribute = hasAttribute || attrFirst.String() == attrSecond.String()
 		}
 		if !hasAttribute {
 			return false


### PR DESCRIPTION
## Compliance with go vet and golint

With the exception of adding some documentation, this pull request is completely cosmetic. I wanted to make the authorization compliant with go vet and golint standards.