### PR TITLE
Default interceptor

### DIFF
--- a/mw/auth/interceptor.go
+++ b/mw/auth/interceptor.go
@@ -137,3 +137,16 @@ func (a Authorizer) authFunc(factory func() pep.Client) grpc_auth.AuthFunc {
 		return ctx, nil
 	}
 }
+
+func makeInterceptor(a string, b Builder, h Handler) grpc.UnaryServerInterceptor {
+	authorizer := Authorizer{PDPAddress: a, Bldr: b, Hdlr: h}
+	return grpc_auth.UnaryServerInterceptor(authorizer.AuthFunc())
+}
+
+func DefaultAuthInterceptor(authzAddress string) grpc.UnaryServerInterceptor {
+	return makeInterceptor(
+		authzAddress,
+		NewBuilder(WithJWT(nil), WithRequest()),
+		NewHandler(),
+	)
+}

--- a/mw/auth/options.go
+++ b/mw/auth/options.go
@@ -86,7 +86,6 @@ func getRequestDetails(ctx context.Context) (string, string, error) {
 	if !ok {
 		return "", "", ErrInternal
 	}
-	fmt.Println(fullMethodString)
 	return path.Dir(fullMethodString)[1:], path.Base(fullMethodString), nil
 }
 


### PR DESCRIPTION
# Default Interceptor

This pull request introduces `DefaultAuthInterceptor`, which creates a standard authorization interceptor that covers most use cases. Developers won't have to learn the nuances of the toolkit's approach to authorization; they can instead called `DefaultAuthInterceptor` to do the heavy-lifting for them.