### PR TITLE
Rename collection operator middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For this purpose `auth.GetAccountID(ctx, nil)` function can be used:
 func (s *contactsServer) Read(ctx context.Context, req *ReadRequest) (*ReadResponse, error) {
 	input := req.GetContact()
 
-	accountID, err := mw.GetAccountID(ctx, nil)
+	accountID, err := auth.GetAccountID(ctx, nil)
 	if err == nil {
 		input.AccountId = accountID
 	} else if input.GetAccountId() == "" {
@@ -575,7 +575,7 @@ message MyRequest {
 ```
 
 After you declare one of collection operator in your `proto` message you need
-to add `mw.WithCollectionOperator` server interceptor to the chain in your
+to add `collection_operators.UnaryServerInterceptor` server interceptor to the chain in your
 gRPC service.
 
 ```golang
@@ -583,7 +583,7 @@ gRPC service.
     grpc.UnaryInterceptor(
       grpc_middleware.ChainUnaryServer( // middleware chain
         ...
-        mw.WithCollectionOperator(), // collection operators
+        collection_operators.UnaryServerInterceptor(), // collection operators
         ...
       ),
     ),
@@ -691,7 +691,7 @@ func (s *myServiceImpl) MyMethod(ctx context.Context, req *MyRequest) (*MyRespon
 
 Also you may want to declare sorting parameter in your `proto` message.
 In this case it will be populated automatically if you using
-`mw.WithCollectionOperator` server interceptor.
+`collection_operators.UnaryServerInterceptor` server interceptor.
 
 See documentation in [op package](op/sorting.go)
 

--- a/cli/atlas/templates/cmd/server/main.go.gotmpl
+++ b/cli/atlas/templates/cmd/server/main.go.gotmpl
@@ -30,7 +30,7 @@ func main() {
 				grpc_validator.UnaryServerInterceptor(),
 				{{ if .WithGateway }} 
 				// collection operators middleware
-				mw.WithCollectionOperator(),
+				collection_operators.UnaryServerInterceptor(),
 				{{ end }}
 				// logging middleware
 				grpc_logrus.UnaryServerInterceptor(logrus.NewEntry(logger)),

--- a/mw/operator.go
+++ b/mw/operator.go
@@ -1,4 +1,4 @@
-package mw
+package collection_operators
 
 import (
 	"context"
@@ -14,13 +14,13 @@ import (
 	"github.com/infobloxopen/atlas-app-toolkit/op"
 )
 
-// WithCollectionOperator returns grpc.UnaryServerInterceptor
+// UnaryServerInterceptor returns grpc.UnaryServerInterceptor
 // that should be used as a middleware if an user's request message
 // defines any of collection operators.
 //
 // Returned middleware populates collection operators from gRPC metadata if
 // they defined in a request message.
-func WithCollectionOperator() grpc.UnaryServerInterceptor {
+func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (res interface{}, err error) {
 		// handle panic
 		defer func() {

--- a/mw/operator_test.go
+++ b/mw/operator_test.go
@@ -1,4 +1,4 @@
-package mw
+package collection_operators
 
 import (
 	"context"
@@ -20,7 +20,7 @@ type response struct {
 	PageInfo *op.PageInfo
 }
 
-func TestWithCollectionOperatorSorting(t *testing.T) {
+func TestUnaryServerInterceptorSorting(t *testing.T) {
 	hreq, err := http.NewRequest(http.MethodGet, "http://app.com?_order_by=name asc, age desc", nil)
 	if err != nil {
 		t.Fatalf("failed to build new http request: %s", err)
@@ -29,7 +29,7 @@ func TestWithCollectionOperatorSorting(t *testing.T) {
 
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	req := &request{Sorting: nil}
-	interceptor := WithCollectionOperator()
+	interceptor := UnaryServerInterceptor()
 
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		msg := req.(*request)
@@ -55,7 +55,7 @@ func TestWithCollectionOperatorSorting(t *testing.T) {
 	}
 }
 
-func TestWithCollectionOperatorPagination(t *testing.T) {
+func TestUnaryServerInterceptorPagination(t *testing.T) {
 	hreq, err := http.NewRequest(http.MethodGet, "http://app.com?_limit=10&_offset=20", nil)
 	if err != nil {
 		t.Fatalf("failed to build new http request: %s", err)
@@ -65,7 +65,7 @@ func TestWithCollectionOperatorPagination(t *testing.T) {
 
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	req := &request{Pagination: nil}
-	interceptor := WithCollectionOperator()
+	interceptor := UnaryServerInterceptor()
 
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		msg := req.(*request)


### PR DESCRIPTION
  - refactor the name to match gRPC-gateway convention
  - fix minor issue in README.md
  - fix test cases to match new naming convention
  - referencing issue #24