### PR TITLE
Good to include read and write timeouts in server

### DIFF
--- a/cli/atlas/templates/cmd/gateway/main.go.gotmpl
+++ b/cli/atlas/templates/cmd/gateway/main.go.gotmpl
@@ -29,10 +29,16 @@ func main() {
 	}
 	// map HTTP endpoints to handlers
 	mux := http.NewServeMux()
+	s := &http.Server{
+				Addr:           GatewayAddress,
+				Handler:        mux,
+				ReadTimeout:    10 * time.Second,
+				WriteTimeout:   10 * time.Second,
+				}
 	mux.Handle(cmd.GatewayURL, serverHandler)
 	mux.HandleFunc("/swagger/", SwaggerHandler)
 	// serve handlers on the gateway address
-	http.ListenAndServe(GatewayAddress, mux)
+	log.Fatal(s.ListenAndServe())
 }
 
 func init() {


### PR DESCRIPTION
Its to enforce timeouts on client connections.

`ReadTimeout` covers the time from when the connection is accepted to when the request body is fully read.
`WriteTimeout` covers the time from the end of the request header read to the end of the response.