### PR TITLE
Update WithRequest option to include an appID argument

### DIFF
--- a/auth/interceptor.go
+++ b/auth/interceptor.go
@@ -143,10 +143,10 @@ func makeInterceptor(a string, b Builder, h Handler) grpc.UnaryServerInterceptor
 	return grpc_auth.UnaryServerInterceptor(authorizer.AuthFunc())
 }
 
-func UnaryServerInterceptor(authzAddress string) grpc.UnaryServerInterceptor {
+func UnaryServerInterceptor(authzAddress, appID string) grpc.UnaryServerInterceptor {
 	return makeInterceptor(
 		authzAddress,
-		NewBuilder(WithJWT(nil), WithRequest()),
+		NewBuilder(WithJWT(nil), WithRequest(appID)),
 		NewHandler(),
 	)
 }

--- a/auth/options.go
+++ b/auth/options.go
@@ -55,17 +55,21 @@ func WithCallback(attr attributer) option {
 // to Themis in the authorization request. Specifically, this includes the gRPC
 // service name (e.g. AddressBook) and the corresponding function that is
 // called by the client (e.g. ListPersons)
-func WithRequest() option {
+func WithRequest(appID string) option {
+	// assume PARGs are in default namespace if no appID is provided
+	if appID == "" {
+		appID = "default"
+	}
 	withRequestFunc := func(ctx context.Context) ([]*pdp.Attribute, error) {
 		service, method, err := getRequestDetails(ctx)
 		if err != nil {
 			return nil, err
 		}
-		service = stripPackageName(service)
+		operation := fmt.Sprintf("%s.%s", stripPackageName(service), method)
 		attributes := []*pdp.Attribute{
-			&pdp.Attribute{Id: "operation", Type: "string", Value: method},
-			// lowercase the service to match PARG naming conventions
-			&pdp.Attribute{Id: "application", Type: "string", Value: strings.ToLower(service)},
+			&pdp.Attribute{Id: "operation", Type: "string", Value: operation},
+			// lowercase the appID to match PARG namespace
+			&pdp.Attribute{Id: "application", Type: "string", Value: strings.ToLower(appID)},
 		}
 		return attributes, nil
 	}

--- a/auth/options_test.go
+++ b/auth/options_test.go
@@ -130,22 +130,34 @@ func (m mockTransportStream) SetTrailer(metadata.MD) error { return nil }
 func TestWithRequest(t *testing.T) {
 	var tests = []struct {
 		stream   *mockTransportStream
+		appID    string
 		expected []*pdp.Attribute
 		err      error
 	}{
 		{
 			stream: &mockTransportStream{method: "/PetStore/ListPets"},
+			appID:  "ShoppingMall",
 			expected: []*pdp.Attribute{
-				{Id: "operation", Type: "string", Value: "ListPets"},
-				{Id: "application", Type: "string", Value: "petstore"},
+				{Id: "operation", Type: "string", Value: "PetStore.ListPets"},
+				{Id: "application", Type: "string", Value: "shoppingmall"},
 			},
 			err: nil,
 		},
 		{
 			stream: &mockTransportStream{method: "/atlas.example.PetStore/ListPets"},
+			appID:  "ShoppingMall",
 			expected: []*pdp.Attribute{
-				{Id: "operation", Type: "string", Value: "ListPets"},
-				{Id: "application", Type: "string", Value: "petstore"},
+				{Id: "operation", Type: "string", Value: "PetStore.ListPets"},
+				{Id: "application", Type: "string", Value: "shoppingmall"},
+			},
+			err: nil,
+		},
+		{
+			stream: &mockTransportStream{method: "/PetStore/ListPets"},
+			appID:  "",
+			expected: []*pdp.Attribute{
+				{Id: "operation", Type: "string", Value: "PetStore.ListPets"},
+				{Id: "application", Type: "string", Value: "default"},
 			},
 			err: nil,
 		},
@@ -163,7 +175,7 @@ func TestWithRequest(t *testing.T) {
 				test.stream,
 			)
 		}
-		builder := NewBuilder(WithRequest())
+		builder := NewBuilder(WithRequest(test.appID))
 		req, err := builder.build(ctx)
 		if err != test.err {
 			t.Errorf("Unexpected error when building request: %v", err)


### PR DESCRIPTION
# Add appID Argument to WithRequest

The current iteration of the `WithRequest` option isn't quite what we want. It uses the microservice name (e.g. PetStore) as the application name. To resolve this issue, developers will now provide an application ID (e.g. ShoppingMall) to the `WithRequest` option. The application ID will associate their service to a specific application.

Operations in PARG files should now be prefixed with a service name. Take a look at [this pull request](https://github.com/infobloxopen/atlas-contacts-app/pull/17) to see up-to-date PARGs.

_This is a breaking change_