### PR TITLE
Implement intercepter for validating parameter dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ check-fmt:
 
 .gen-op:
 	docker run --rm -v $(PROJECT_ROOT):/go/src/$(REPO) $(GENTOOL_IMAGE) \
-	--go_out=:. $(REPO)/op/collection_operators.proto
+	--go_out=:. $(REPO)/query/collection_operators.proto
 
 .gen-errdetails:
 	docker run --rm -v $(PROJECT_ROOT):/go/src/$(REPO) $(GENTOOL_IMAGE) \

--- a/gateway/operator.go
+++ b/gateway/operator.go
@@ -18,14 +18,14 @@ import (
 const (
 	filterQueryKey           = "_filter"
 	filterMetaKey            = "operator-filter"
-	sortQueryKey             = "_order_by"
-	sortMetaKey              = "operator-sort"
+	SortQueryKey             = "_order_by"
+	SortMetaKey              = "operator-sort"
 	fieldsQueryKey           = "_fields"
 	fieldsMetaKey            = "operator-fields"
-	limitQueryKey            = "_limit"
-	limitMetaKey             = "operator-limit"
-	offsetQueryKey           = "_offset"
-	offsetMetaKey            = "operator-offset"
+	LimitQueryKey            = "_limit"
+	LimitMetaKey             = "operator-limit"
+	OffsetQueryKey           = "_offset"
+	OffsetMetaKey            = "operator-offset"
 	pageTokenQueryKey        = "_page_token"
 	pageTokenMetaKey         = "operator-page-token"
 	pageInfoSizeMetaKey      = "status-page-info-size"
@@ -51,8 +51,8 @@ func MetadataAnnotator(ctx context.Context, req *http.Request) metadata.MD {
 	vals := req.URL.Query()
 	mdmap := make(map[string]string)
 
-	if v := vals.Get(sortQueryKey); v != "" {
-		mdmap[runtime.MetadataPrefix+sortMetaKey] = v
+	if v := vals.Get(SortQueryKey); v != "" {
+		mdmap[runtime.MetadataPrefix+SortMetaKey] = v
 	}
 	if v := vals.Get(fieldsQueryKey); v != "" {
 		mdmap[runtime.MetadataPrefix+fieldsMetaKey] = v
@@ -62,12 +62,12 @@ func MetadataAnnotator(ctx context.Context, req *http.Request) metadata.MD {
 		mdmap[runtime.MetadataPrefix+filterMetaKey] = v
 	}
 
-	if v := vals.Get(offsetQueryKey); v != "" {
-		mdmap[runtime.MetadataPrefix+offsetMetaKey] = v
+	if v := vals.Get(OffsetQueryKey); v != "" {
+		mdmap[runtime.MetadataPrefix+OffsetMetaKey] = v
 	}
 
-	if v := vals.Get(limitQueryKey); v != "" {
-		mdmap[runtime.MetadataPrefix+limitMetaKey] = v
+	if v := vals.Get(LimitQueryKey); v != "" {
+		mdmap[runtime.MetadataPrefix+LimitMetaKey] = v
 	}
 
 	if v := vals.Get(pageTokenQueryKey); v != "" {
@@ -84,7 +84,7 @@ func MetadataAnnotator(ctx context.Context, req *http.Request) metadata.MD {
 // `status.Error(codes.InvalidArgument, parser_error)`
 // See: `query.ParseSorting` for details.
 func Sorting(ctx context.Context) (*query.Sorting, error) {
-	raw, ok := Header(ctx, sortMetaKey)
+	raw, ok := Header(ctx, SortMetaKey)
 	if !ok {
 		return nil, nil
 	}
@@ -129,8 +129,8 @@ func Pagination(ctx context.Context) (*query.Pagination, error) {
 		return v, nil
 	}
 
-	l, lok := Header(ctx, limitMetaKey)
-	o, ook := Header(ctx, offsetMetaKey)
+	l, lok := Header(ctx, LimitMetaKey)
+	o, ook := Header(ctx, OffsetMetaKey)
 	pt, ptok := Header(ctx, pageTokenMetaKey)
 
 	if !lok && !ook && !ptok {

--- a/params/interceptor.go
+++ b/params/interceptor.go
@@ -1,0 +1,31 @@
+package params
+
+import (
+	"context"
+
+	"github.com/infobloxopen/atlas-app-toolkit/gateway"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// UnaryServerInterceptor returns grpc.UnaryServerInterceptor
+// that should be used as a middleware to validate query parameter dependencies
+func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (res interface{}, err error) {
+
+		_, exists := gateway.Header(ctx, gateway.SortMetaKey)
+		if !exists {
+			_, lexists := gateway.Header(ctx, gateway.LimitMetaKey)
+			_, oexists := gateway.Header(ctx, gateway.OffsetMetaKey)
+
+			if lexists || oexists {
+				err = status.Errorf(codes.InvalidArgument, "parameters interceptor: paramters(s) %s/%s can't be used without %s",
+					gateway.LimitQueryKey, gateway.OffsetQueryKey, gateway.SortQueryKey)
+				return nil, err
+			}
+		}
+		// returning from the request call
+		return handler(ctx, req)
+	}
+}

--- a/params/interceptor_test.go
+++ b/params/interceptor_test.go
@@ -1,0 +1,61 @@
+package params
+
+import (
+	"context"
+	"testing"
+
+	"github.com/infobloxopen/atlas-app-toolkit/gateway"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/transport"
+)
+
+type testRequest struct{}
+
+type testResponse struct{}
+
+var handler = func(ctx context.Context, req interface{}) (interface{}, error) {
+	return &testResponse{}, nil
+}
+
+func DummyContextWithServerTransportStream() context.Context {
+	expectedStream := &transport.Stream{}
+	return grpc.NewContextWithServerTransportStream(context.Background(), expectedStream)
+}
+
+func TestUnaryServerInterceptorValidCases(t *testing.T) {
+	data := [][]string{
+		[]string{"somekey", "somevalue"},
+		[]string{gateway.SortMetaKey, "name"},
+		[]string{gateway.SortMetaKey, "name", gateway.LimitMetaKey, "3"},
+		[]string{gateway.SortMetaKey, "name", gateway.OffsetMetaKey, "3"},
+		[]string{gateway.SortMetaKey, "name", gateway.OffsetMetaKey, "3", gateway.LimitMetaKey, "3"},
+	}
+	ctx := DummyContextWithServerTransportStream()
+	for i, pms := range data {
+		md := metadata.Pairs(pms...)
+		newCtx := metadata.NewIncomingContext(ctx, md)
+		_, err := UnaryServerInterceptor()(newCtx, testRequest{}, nil, handler)
+		if err != nil {
+			t.Fatalf("data item %d, unexpected error : %v", i, err)
+		}
+	}
+
+}
+
+func TestUnaryServerInterceptorErrorCases(t *testing.T) {
+	data := [][]string{
+		[]string{gateway.LimitMetaKey, "3"},
+		[]string{gateway.OffsetMetaKey, "3"},
+		[]string{gateway.OffsetMetaKey, "3", gateway.LimitMetaKey, "3"},
+	}
+	ctx := DummyContextWithServerTransportStream()
+	for i, pms := range data {
+		md := metadata.Pairs(pms...)
+		newCtx := metadata.NewIncomingContext(ctx, md)
+		_, err := UnaryServerInterceptor()(newCtx, testRequest{}, nil, handler)
+		if err == nil {
+			t.Fatalf("expected error for data item %d", i)
+		}
+	}
+}


### PR DESCRIPTION
In NGP-913, Arnaud Klein requested "An error should be thrown when _offset and/or _limit are used without _order_by".
In "REST API Syntax Specification" I didn't find such dependencies, and it looks like non common.
So do we need to add such interceptor into toolkit? or service developers should implement it for their needs?