### PR TITLE
requestid middeware: add Requst-Id to logger

### DIFF
--- a/requestid/interceptor.go
+++ b/requestid/interceptor.go
@@ -28,6 +28,8 @@ func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 		}()
 
 		reqID := handleRequestID(ctx)
+		// add request id to logger
+		addRequestIDToLogger(ctx, reqID)
 
 		ctx = NewContext(ctx, reqID)
 

--- a/requestid/requestid.go
+++ b/requestid/requestid.go
@@ -4,7 +4,9 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
 	"github.com/infobloxopen/atlas-app-toolkit/gateway"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -40,4 +42,8 @@ func FromContext(ctx context.Context) (reqID string, exists bool) {
 func NewContext(ctx context.Context, reqID string) context.Context {
 	md := metadata.Pairs(DefaultRequestIDKey, reqID)
 	return metadata.NewOutgoingContext(ctx, md)
+}
+
+func addRequestIDToLogger(ctx context.Context, reqID string) {
+	ctxlogrus.AddFields(ctx, logrus.Fields{DefaultRequestIDKey: reqID})
 }


### PR DESCRIPTION
  - add Request-Id as key value pair additional fields to be
    used by logger. This value will then be used while logging each requests
    with Request-Id parameter.