### PR TITLE
Add transaction hook

### DIFF
--- a/gorm/transaction.go
+++ b/gorm/transaction.go
@@ -47,8 +47,8 @@ type Transaction struct {
 	afterCommitHook []func(context.Context)
 }
 
-func (t *Transaction) AddAfterCommitHook(f []func(context.Context)) {
-	t.afterCommitHook = f
+func (t *Transaction) AddAfterCommitHook(hooks ...func(context.Context)) {
+	t.afterCommitHook = append(t.afterCommitHook, hooks...)
 }
 
 func BeginFromContext(ctx context.Context) (*gorm.DB, error) {

--- a/gorm/transaction.go
+++ b/gorm/transaction.go
@@ -104,7 +104,7 @@ func (t *Transaction) Commit(ctx context.Context) error {
 	defer t.mu.Unlock()
 	t.current.Commit()
 	err := t.current.Error
-	if err == nil && len(t.afterCommitHook) != 0 {
+	if err == nil {
 		for i := range t.afterCommitHook {
 			t.afterCommitHook[i](ctx)
 		}

--- a/gorm/transaction_test.go
+++ b/gorm/transaction_test.go
@@ -161,14 +161,14 @@ func TestTransaction_Commit(t *testing.T) {
 		t.Fatalf("failed to open gorm db - %s", err)
 	}
 	txn := &Transaction{parent: gdb}
-
+	ctx := context.Background()
 	// test current transaction is nil
-	if err := txn.Commit(); err != nil {
+	if err := txn.Commit(ctx); err != nil {
 		t.Errorf("unexpected error %s", err)
 	}
 
 	txn.Begin()
-	if err := txn.Commit(); err != nil {
+	if err := txn.Commit(ctx); err != nil {
 		t.Errorf("failed to commit transaction - %s", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/gorm/transaction_test.go
+++ b/gorm/transaction_test.go
@@ -180,6 +180,36 @@ func TestTransaction_Commit(t *testing.T) {
 	}
 }
 
+func TestTransaction_AfterCommitHook(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock - %s", err)
+	}
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	gdb, err := gorm.Open("postgres", db)
+	if err != nil {
+		t.Fatalf("failed to open gorm db - %s", err)
+	}
+	txn := &Transaction{parent: gdb}
+	txn.Begin()
+
+	called := false
+	f := func(context.Context) { called = true; return }
+	txn.AddAfterCommitHook([]func(ctx context.Context){f})
+	ctx := context.Background()
+	if err := txn.Commit(ctx); err != nil {
+		t.Errorf("failed to commit transaction - %s", err)
+	}
+	if !called {
+		t.Errorf("did not fire the hook")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("failed to commit transaction - %s", err)
+	}
+
+}
 func TestTransaction_Rollback(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/gorm/transaction_test.go
+++ b/gorm/transaction_test.go
@@ -196,8 +196,8 @@ func TestTransaction_AfterCommitHook(t *testing.T) {
 	txn.Begin()
 
 	called := false
-	f := func(context.Context) { called = true; return }
-	txn.AddAfterCommitHook([]func(ctx context.Context){f})
+	hook := func(context.Context) { called = true; return }
+	txn.AddAfterCommitHook(hook)
 	ctx := context.Background()
 	if err := txn.Commit(ctx); err != nil {
 		t.Errorf("failed to commit transaction - %s", err)


### PR DESCRIPTION
- N* applications need to send notifications to another service about modified objects in a course of a request. We need to trigger the notification only when the transaction commits. 
- Adding a hook to toolkit transaction was an option that was discussed  in the team and in the toolkit scrum.
- The hook was added as part of transaction struct, it can be set by the applications.
- We need the context in the transaciton, so other middleware can put information about actual changes here. 
- Here is a link to an example on how this hook can be used in the application.
https://github.com/Infoblox-CTO/ddi.dns.config/compare/toolkit...friahi65:TK-45717-Design
