### PR TITLE
Replace deprecated methods

### DIFF
--- a/gateway/errors.go
+++ b/gateway/errors.go
@@ -64,7 +64,7 @@ func (h *ProtoErrorHandler) MessageHandler(ctx context.Context, mux *runtime.Ser
 
 	md, ok := runtime.ServerMetadataFromContext(ctx)
 	if !ok {
-		grpclog.Printf("error handler: failed to extract ServerMetadata from context")
+		grpclog.Infof("error handler: failed to extract ServerMetadata from context")
 	}
 
 	handleForwardResponseServerMetadata(h.OutgoingHeaderMatcher, rw, md)
@@ -100,7 +100,7 @@ func (h *ProtoErrorHandler) writeError(ctx context.Context, headerWritten bool, 
 		case *errfields.FieldInfo:
 			fields = d
 		default:
-			grpclog.Printf("error handler: failed to recognize error message")
+			grpclog.Infof("error handler: failed to recognize error message")
 			rw.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -120,16 +120,16 @@ func (h *ProtoErrorHandler) writeError(ctx context.Context, headerWritten bool, 
 
 	buf, merr := marshaler.Marshal(restErr)
 	if merr != nil {
-		grpclog.Printf("error handler: failed to marshal error message %q: %v", restErr, merr)
+		grpclog.Infof("error handler: failed to marshal error message %q: %v", restErr, merr)
 		rw.WriteHeader(http.StatusInternalServerError)
 
 		if _, err := io.WriteString(rw, fmt.Sprintf(fallback, merr)); err != nil {
-			grpclog.Printf("error handler: failed to write response: %v", err)
+			grpclog.Infof("error handler: failed to write response: %v", err)
 		}
 		return
 	}
 
 	if _, err := rw.Write(buf); err != nil {
-		grpclog.Printf("error handler: failed to write response: %v", err)
+		grpclog.Infof("error handler: failed to write response: %v", err)
 	}
 }

--- a/gateway/response.go
+++ b/gateway/response.go
@@ -54,7 +54,7 @@ func NewForwardResponseStream(out runtime.HeaderMatcherFunc, meh runtime.ProtoEr
 func (fw *ResponseForwarder) ForwardMessage(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, rw http.ResponseWriter, req *http.Request, resp proto.Message, opts ...func(context.Context, http.ResponseWriter, proto.Message) error) {
 	md, ok := runtime.ServerMetadataFromContext(ctx)
 	if !ok {
-		grpclog.Printf("forward response message: failed to extract ServerMetadata from context")
+		grpclog.Infof("forward response message: failed to extract ServerMetadata from context")
 		fw.MessageErrHandler(ctx, mux, marshaler, rw, req, fmt.Errorf("forward response message: internal error"))
 	}
 
@@ -79,13 +79,13 @@ func (fw *ResponseForwarder) ForwardMessage(ctx context.Context, mux *runtime.Se
 	// -- In this way the success data becomes just a tag added to an existing structure.
 	data, err := marshaler.Marshal(resp)
 	if err != nil {
-		grpclog.Printf("forward response: failed to marshal response: %v", err)
+		grpclog.Infof("forward response: failed to marshal response: %v", err)
 		fw.MessageErrHandler(ctx, mux, marshaler, rw, req, err)
 	}
 
 	var dynmap map[string]interface{}
 	if err := marshaler.Unmarshal(data, &dynmap); err != nil {
-		grpclog.Printf("forward response: failed to unmarshal response: %v", err)
+		grpclog.Infof("forward response: failed to unmarshal response: %v", err)
 		fw.MessageErrHandler(ctx, mux, marshaler, rw, req, err)
 	}
 
@@ -105,7 +105,7 @@ func (fw *ResponseForwarder) ForwardMessage(ctx context.Context, mux *runtime.Se
 
 		if !exists || location == "" {
 			err := fmt.Errorf("Header Location should be set for long running operation")
-			grpclog.Printf("forward response: %v", err)
+			grpclog.Infof("forward response: %v", err)
 			fw.MessageErrHandler(ctx, mux, marshaler, rw, req, err)
 		}
 		rw.Header().Add("Location", location)
@@ -118,14 +118,14 @@ func (fw *ResponseForwarder) ForwardMessage(ctx context.Context, mux *runtime.Se
 
 	data, err = marshaler.Marshal(dynmap)
 	if err != nil {
-		grpclog.Printf("forward response: failed to marshal response: %v", err)
+		grpclog.Infof("forward response: failed to marshal response: %v", err)
 		fw.MessageErrHandler(ctx, mux, marshaler, rw, req, err)
 	}
 
 	rw.WriteHeader(rst.HTTPStatus)
 
 	if _, err = rw.Write(data); err != nil {
-		grpclog.Printf("forward response: failed to write response: %v", err)
+		grpclog.Infof("forward response: failed to write response: %v", err)
 	}
 
 	handleForwardResponseTrailer(rw, md)
@@ -136,14 +136,14 @@ func (fw *ResponseForwarder) ForwardMessage(ctx context.Context, mux *runtime.Se
 func (fw *ResponseForwarder) ForwardStream(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, rw http.ResponseWriter, req *http.Request, recv func() (proto.Message, error), opts ...func(context.Context, http.ResponseWriter, proto.Message) error) {
 	flusher, ok := rw.(http.Flusher)
 	if !ok {
-		grpclog.Printf("forward response stream: flush not supported in %T", rw)
+		grpclog.Infof("forward response stream: flush not supported in %T", rw)
 		fw.StreamErrHandler(ctx, false, mux, marshaler, rw, req, fmt.Errorf("forward response message: internal error"))
 		return
 	}
 
 	md, ok := runtime.ServerMetadataFromContext(ctx)
 	if !ok {
-		grpclog.Printf("forward response stream: failed to extract ServerMetadata from context")
+		grpclog.Infof("forward response stream: failed to extract ServerMetadata from context")
 		fw.StreamErrHandler(ctx, false, mux, marshaler, rw, req, fmt.Errorf("forward response message: internal error"))
 		return
 	}
@@ -176,7 +176,7 @@ func (fw *ResponseForwarder) ForwardStream(ctx context.Context, mux *runtime.Ser
 	}
 
 	if _, err := rw.Write(data); err != nil {
-		grpclog.Printf("forward response stream: failed to write status object: %s", err)
+		grpclog.Infof("forward response stream: failed to write status object: %s", err)
 		return
 	}
 
@@ -208,12 +208,12 @@ func (fw *ResponseForwarder) ForwardStream(ctx context.Context, mux *runtime.Ser
 		}
 
 		if _, err := rw.Write(data); err != nil {
-			grpclog.Printf("forward response stream: failed to write response object: %s", err)
+			grpclog.Infof("forward response stream: failed to write response object: %s", err)
 			return
 		}
 
 		if _, err = rw.Write(delimiter); err != nil {
-			grpclog.Printf("forward response stream: failed to send delimiter chunk: %v", err)
+			grpclog.Infof("forward response stream: failed to send delimiter chunk: %v", err)
 			return
 		}
 		flusher.Flush()
@@ -226,7 +226,7 @@ func handleForwardResponseOptions(ctx context.Context, rw http.ResponseWriter, r
 	}
 	for _, opt := range opts {
 		if err := opt(ctx, rw, resp); err != nil {
-			grpclog.Printf("error handling ForwardResponseOptions: %v", err)
+			grpclog.Infof("error handling ForwardResponseOptions: %v", err)
 			return err
 		}
 	}

--- a/gateway/status.go
+++ b/gateway/status.go
@@ -228,6 +228,6 @@ func HTTPStatusFromCode(code codes.Code) int {
 		return http.StatusInternalServerError
 	}
 
-	grpclog.Printf("Unknown gRPC error code: %v", code)
+	grpclog.Infof("Unknown gRPC error code: %v", code)
 	return http.StatusInternalServerError
 }


### PR DESCRIPTION
`grpclog.Printf` is depricated. Use `grpclog.Infof` as recommended [here](https://godoc.org/google.golang.org/grpc/grpclog#Printf)