### PR TITLE
Add documentation to the auth package

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -4,7 +4,7 @@ This package provides a server-side gRPC interceptor that interfaces with [Themi
 
 It is designed to give developers fine-grained control over who (e.g. specific users) or what (e.g. neighboring services) can access their gRPC service's business logic.
 
-## How it Works
+## Background
 
 If you're unfamiliar with gRPC interceptors and their intended use, please consider reading [this](https://github.com/grpc-ecosystem/go-grpc-middleware#middleware) brief explanation.
 
@@ -12,36 +12,36 @@ The authorization interceptor determines whether or not an API consumer can acce
 
 Here's the authorization interceptor as if it were a living, breathing human: _"Hey Themis, is the sender of request XYZ allowed to access endpoint ABC in my service? They're not? Okay, I'll deny the request!"_
 
-## Add Interceptors
+## Using Interceptors
 If you already use gRPC with Go, your project probably has a bit of code like this.
 
 ```go
-// Define your grpc server
+// define your grpc server
 myServer := grpc.NewServer()
 ```
 This is how you would decorate your server with interceptors.
 
 ```go
-// Define your grpc server
+// define your grpc server
 myServer := grpc.NewServer(
-  rpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
-    // Define your list of grpc interceptors
+  grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
+    // define your list of grpc interceptors
   )),
 )
 ```
 
 Again, the official gRPC GitHub repository [has documentation](https://github.com/grpc-ecosystem/go-grpc-middleware) to explain this process.
 
-## Add the Default AuthZ Interceptor
+## Using the Default AuthZ Interceptor
 
 The `auth` package offers a default authorization interceptor.
 ```go
 themisAddress := "default.themis:5555" 
 applicationID := "shopping-mall"
-// Define your grpc server
+// define your grpc server
 myServer := grpc.NewServer(
-  grpc.UnaryInterceptor(grpc_middleware.ChainStreamServer(
-    // Include the authorization interceptor
+  grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
+    // include the authorization interceptor
     auth.UnaryServerInterceptor(themisAddress, applicationID),
   )),
 )
@@ -49,13 +49,13 @@ myServer := grpc.NewServer(
 In the example above, the `themisAddress` variable corresponds to the host and port of Themis.
 
 
-The `applicationID` maps the interceptor to a specific application. In a microservices environment, you might have multiple services that, as a unit, compose an application (e.g. a "petstore" service, a "coffee shop" service, and a "cellphone kiosk" service might belong to a "shopping mall" application). Each service has its own access control logic, but they're all under the same application umbrella.
+The `applicationID` maps the interceptor to a specific application. In a microservices environment, you might have multiple services that, as a unit, compose an application (e.g. a petstore service, a coffee shop service, and a cellphone kiosk service might belong to a shopping mall application). Each service has its own access control logic, but together they form an application.
 
 When you define your gRPC server, start by using the `auth` package's `UnaryServerInterceptor` interceptor. The `applicationID` associates the interceptor with a specific set of policies.
 
 
 ## Customize the AuthZ Interceptor
-The `auth` package provides a set of options that offer fine-grained control of the authorization interceptor. Options affect how the authorization middleware interfaces with Themis. For example, you might need to permit or deny request using the fields in a JWT. Well, there's an option to handle this use case!
+The `auth` package provides a set of _options_ that offer fine-grained control of the authorization interceptor. Options affect how the authorization middleware interfaces with Themis. For example, you might need to permit or deny request using the fields in a JWT. Well, there's an option to handle this use case!
 
 Interceptor options are your friend because they abstract Themis' API behind a set of well-documented functions. Below is a detailed description of each option.
 
@@ -66,21 +66,21 @@ import (
 	"google.golang.org/grpc"
 )
 ...
-// Build a new authorizer and specify some options. The authorizer will
+// build a new authorizer and specify some options. the authorizer will
 // create authorization middleware based on options that get provided
 // by the user.
 authorizer := Authorizer{
-  PDPAddress: "themis.default",
+  PDPAddress: "themis.default:5555",
   Bldr: NewBuilder(
-    // This is where options are provided by the user
+    // this is where options are provided by the user
     WithRequest("shopping-mall"),
     WithJWT(nil),
   ),
   Hdlr: NewHandler(),
 }
 
-// Create an authorization function. The authorization function is responsible
-// for checking with Themis to determine if a request should be permitted
+// create an authorization function. the authorization function is responsible
+// for checking with themis to determine if a request should be permitted
 // or denied.
 authFunc := authorizer.AuthFunc()
 myServer := grpc.NewServer(
@@ -111,23 +111,6 @@ This option enables token-based authorization with JWT. When requests reach the 
 ```
 Each of the fields in the above example would be sent to Themis as part of the authorization request.
 
-### `WithCallback`
-
-This option allows for application-specific authorization behavior. The toolkit offers a robust set of authorization options, but you might need specialized, non-generalizable authorization logic to satisfy your access control requirements.
-
-To use the `WithCallback` option, you must be somewhat familiar with the API for Themis, which is defined [here](https://github.com/infobloxopen/themis/blob/master/proto/service.proto).
-
-```go
-myCallBackFunction := func(ctx context.Context) ([]*pdp.Attribute, error){
-  myAttributes := []*pdp.Attribute{
-    {Id: "city", Type: "string", Value: "vancouver"},
-    {Id: "country", Type: "string", Value: "canada"},
-  }
-  return myAttributes, nil
-}
-```
-Each request to the Themis will include an two additional attributes: the city and country (although both are hardcoded). The point being, you can modify the authorization logic without making changes to the toolkit code.
-
 ### `WithRequest`
 
 This option includes information about the gRPC request as part of the request to Themis. The interceptor will add the following attributes.
@@ -143,3 +126,19 @@ This option uses metadata from a TLS-authenticated client. When included, the fo
 - The TLS certificate issuer (if authenticated)
 - The TLS common subject name (if authenticated)
 
+### `WithCallback`
+
+This option allows for application-specific authorization behavior. The toolkit offers a robust set of authorization options, but you might need specialized, non-generalizable authorization logic to satisfy your access control requirements.
+
+To use the `WithCallback` option, you must be somewhat familiar with the API for Themis, which is defined [here](https://github.com/infobloxopen/themis/blob/master/proto/service.proto).
+
+```go
+myCallBackFunction := func(ctx context.Context) ([]*pdp.Attribute, error){
+  myAttributes := []*pdp.Attribute{
+    {Id: "city", Type: "string", Value: "vancouver"},
+    {Id: "country", Type: "string", Value: "canada"},
+  }
+  return myAttributes, nil
+}
+```
+Each request to the Themis will include an two additional attributes: the city and country (although both are hardcoded). The point is, you can modify the authorization logic without making changes to the toolkit code.

--- a/auth/README.md
+++ b/auth/README.md
@@ -57,8 +57,11 @@ When you define your gRPC server, start by using the `auth` package's `UnaryServ
 ## Customize the AuthZ Interceptor
 The `auth` package provides a set of _options_ that offer fine-grained control of the authorization interceptor. Options affect how the authorization middleware interfaces with Themis. For example, you might need to permit or deny request using the fields in a JWT. Well, there's an option to handle this use case!
 
-Interceptor options are your friend because they abstract Themis' API behind a set of well-documented functions. Below is a detailed description of each option.
+Interceptor options are helpful because they abstract Themis' API behind a set of well-documented functions.
 
+### Applying Options
+
+The example below shows how to would configure your application's authorization logic using options.
 
 ```go
 import (
@@ -91,14 +94,17 @@ myServer := grpc.NewServer(
 )
 ```
 
-You'll likely find the Go documentation helpful, too.
-
+This readme has a description of each option below, but you can also host a local GoDoc server.
 ```sh
 godoc -http :6060
+open http://localhost:6060/pkg/github.com/infobloxopen/atlas-app-toolkit/auth
 ```
-Visit [this link](http://localhost:6060/pkg/github.com/infobloxopen/atlas-app-toolkit/auth/) in your browser.
 
-### `WithJWT`
+### Interceptor Options
+
+Here are the authorization options that are currently provided by the toolkit. 
+
+#### `WithJWT`
 
 This option enables token-based authorization with JWT. When requests reach the authorization interceptor, the interceptor will include the full JWT payload in a given authorization request to Themis.
 
@@ -111,14 +117,14 @@ This option enables token-based authorization with JWT. When requests reach the 
 ```
 Each of the fields in the above example would be sent to Themis as part of the authorization request.
 
-### `WithRequest`
+#### `WithRequest`
 
 This option includes information about the gRPC request as part of the request to Themis. The interceptor will add the following attributes.
 
 - The gRPC service name (e.g. `/PetStore`)
 - The gRPC function name (e.g. `ListAllPets`)
 
-### `WithTLS`
+#### `WithTLS`
 
 This option uses metadata from a TLS-authenticated client. When included, the following options are included in a request to Themis.
 
@@ -126,7 +132,7 @@ This option uses metadata from a TLS-authenticated client. When included, the fo
 - The TLS certificate issuer (if authenticated)
 - The TLS common subject name (if authenticated)
 
-### `WithCallback`
+#### `WithCallback`
 
 This option allows for application-specific authorization behavior. The toolkit offers a robust set of authorization options, but you might need specialized, non-generalizable authorization logic to satisfy your access control requirements.
 

--- a/auth/README.md
+++ b/auth/README.md
@@ -1,0 +1,133 @@
+# Authorization Interceptor
+
+This package provides a server-side gRPC interceptor that interfaces with Themis, a policy engine that is developed and maintained by Infoblox. It is designed to give developers fine-grained control over who (e.g. specific users) or what (e.g. neighboring services) can access their gRPC service's business logic.
+
+## How it Works
+When building a gRPC server, a developer can supply his or her server with a collection of _gRPC server-side interceptors_. Each request that's sent to the gRPC server will traverse the gRPC interceptors before reaching the server's business logic. At any point, an interceptor can stop a given request from advancing to the application.
+
+Here are some common usages for gRPC interceptors.
+
+- Logging (e.g. log to `stdout` on each request)
+- Metrics (e.g. increment a request-counting metric)
+- **Authorization** (e.g. check if the request-sender is allowed to access a given resource)
+
+When the authorization interceptor is enabled, it ensures that whoever or whatever sent the request is allowed to access some endpoint. If they're not, the interceptor issues a `DENY` response, otherwise the request moves to the application itself.
+
+Behold the behavior authorization interceptor as if it were a living, breathing human: _"Hey Themis, is the sender of request XYZ allowed to access endpoint ABC in my service? They're not? Okay, I'll deny the request!"_
+
+## Add Interceptors
+If you already use gRPC with Go, your project probably has a bit of code like this.
+
+```go
+// Define your grpc server
+myServer := grpc.NewServer()
+```
+This is how you would decorate your server with interceptors.
+
+```go
+// Define your grpc server
+myServer := grpc.NewServer(
+  rpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
+    // Define your list of grpc interceptors
+  )),
+)
+```
+
+For more information about adding server-side gRPC interceptors, check out [the documentation](https://github.com/grpc-ecosystem/go-grpc-middleware) on the official gRPC GitHub repository.
+
+## Add the Default AuthZ Interceptor
+
+The `auth` package offers a default authorization interceptor.
+```go
+themisAddress := "default.themis:5555" 
+applicationID := "shopping-mall"
+// Define your grpc server
+myServer := grpc.NewServer(
+  grpc.UnaryInterceptor(grpc_middleware.ChainStreamServer(
+    // Include the authorization interceptor
+    auth.UnaryServerInterceptor(themisAddress, applicationID),
+  )),
+)
+```
+In the example above, the `themisAddress` variable corresponds to the host and port of Themis. The `applicationID`  maps the interceptor to a specific application. In a microservices environment, you might have multiple services that, as a unit, compose an application (e.g. a "petstore" service, a "coffee shop" service, and a "cellphone kiosk" service might belong to a "shopping mall" application). Each service has its own access control logic, but they're all under the same application umbrella.
+
+When you define your gRPC server, start by using the `auth` package's `UnaryServerInterceptor` interceptor. The `applicationID` associates the interceptor with a specific set of policies.
+
+
+## Customize the AuthZ Interceptor
+The `auth` package provides a set of options that offer fine-grained control of the authorization interceptor. Options affect how the authorization middleware interfaces with Themis. For example, you might need to permit or deny request using the fields in a JWT. Well, there's an option to handle this use case!
+
+Interceptor options are your friend because they abstract Themis' API behind a set of well-documented functions. Below is a detailed description of each option.
+
+
+```go
+import (
+	"github.com/grpc-ecosystem/go-grpc-middleware/auth"
+	"google.golang.org/grpc"
+)
+...
+// Build a new authorizer and specify some options. The authorizer will
+// create authorization middleware based on options that get provided
+// by the user.
+authorizer := Authorizer{
+  PDPAddress: "themis.default",
+  Bldr: NewBuilder(
+    // This is where options are provided by the user
+    WithRequest("shopping-mall"),
+    WithJWT(nil),
+  ),
+  Hdlr: NewHandler(),
+}
+
+// Create an authorization function. The authorization function is responsible
+// for checking with Themis to determine if a request should be permitted
+// or denied.
+authFunc := authorizer.AuthFunc()
+myServer := grpc.NewServer(
+  grpc.UnaryInterceptor(grpc_middleware.ChainStreamServer(
+    // include the authorization interceptor
+    grpc_auth.UnaryServerInterceptor(authFunc)
+  )),
+)
+```
+
+You'll likely find the Go documentation helpful, too.
+
+```sh
+godoc -http :6060
+```
+Visit [this link](http://localhost:6060/pkg/github.com/infobloxopen/atlas-app-toolkit/auth/) in your browser.
+
+### `WithJWT`
+
+For token-based authorization with JWT, the `WithJWT` option will prove useful. When a request reaches the authorization interceptor, it will include the full JWT payload in a given authorization request to Themis.
+
+```json
+{
+   "name":"john doe",
+   "occupation":"astronaut",
+   "group":"admin"
+}
+```
+Each of the fields in the above example would be sent to Themis as part of the authorization request.
+
+### `WithCallback`
+
+The `WithCallback` option allows for application-specific authorization behavior. Although the toolkit offers a robust set of authorization options, you might need specialized, non-generalizable authorization logic to satisfy your access control requirements. Enter the `WithCallback` option.
+
+To use the `WithCallback` option, you must be somewhat familiar with the API for Themis, which is defined [here](https://github.com/infobloxopen/themis/blob/master/proto/service.proto).
+
+```go
+myCallBackFunction := func(ctx context.Context) ([]*pdp.Attribute, error){
+  myAttributes := []*pdp.Attribute{
+    {Id: "city", Type: "string", Value: "vancouver"},
+    {Id: "country", Type: "string", Value: "canada"},
+  }
+  return myAttributes, nil
+}
+```
+In the example callback above, each request to the Themis will include an two additional attributes: the city and country (although both are hardcoded). It shows how you can modify the authorization logic without making changes to the toolkit code.
+
+### `WithRequest`
+
+The `WithRequest` option will


### PR DESCRIPTION
# Add documentation to the auth package

This pull request adds documentation to the `auth` package that explains how to use the authorization middleware.

It covers interceptors at a basic level, then goes into more detail about the authorization interceptor and how to customize its behavior.


It's a WIP at the moment, but I wanted to open a PR to get feedback early-on in the process.