### PR TITLE
Update authorization middleware with changes to authz service

### DIFF
--- a/auth/options.go
+++ b/auth/options.go
@@ -31,6 +31,12 @@ func WithJWT(keyfunc jwt.Keyfunc) option {
 			return attributes, ErrInternal
 		}
 		for k, v := range claims {
+			// HACK: if the multi-tenancy field is included in the JWT payload, it needs
+			// to be changed to "account" because "account" is the multi-tenancy field
+			// used in the authorization service
+			if k == MultiTenancyField {
+				k = "account"
+			}
 			attr := &pdp.Attribute{Id: k, Type: "string", Value: fmt.Sprint(v)}
 			attributes = append(attributes, attr)
 		}
@@ -69,7 +75,7 @@ func WithRequest(appID string) option {
 		}
 		operation := fmt.Sprintf("%s.%s", stripPackageName(service), method)
 		attributes := []*pdp.Attribute{
-			{Id: "operation", Type: "string", Value: operation},
+			{Id: "endpoint", Type: "string", Value: operation},
 			// lowercase the appID to match PARG namespace
 			{Id: "application", Type: "string", Value: strings.ToLower(appID)},
 		}

--- a/auth/options_test.go
+++ b/auth/options_test.go
@@ -37,6 +37,18 @@ func TestWithJWT(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			token: makeToken(jwt.MapClaims{
+				MultiTenancyField: "TestAccount",
+			}, t),
+			expected: []*pdp.Attribute{
+				{Id: "account", Type: "string", Value: "TestAccount"},
+			},
+			keyfunc: func(token *jwt.Token) (interface{}, error) {
+				return []byte(TestSecret), nil
+			},
+			err: nil,
+		},
 		// parse and verify an invalid token
 		{
 			token: makeToken(jwt.MapClaims{
@@ -143,7 +155,7 @@ func TestWithRequest(t *testing.T) {
 			stream: &mockTransportStream{method: "/PetStore/ListPets"},
 			appID:  "ShoppingMall",
 			expected: []*pdp.Attribute{
-				{Id: "operation", Type: "string", Value: "PetStore.ListPets"},
+				{Id: "endpoint", Type: "string", Value: "PetStore.ListPets"},
 				{Id: "application", Type: "string", Value: "shoppingmall"},
 			},
 			err: nil,
@@ -152,7 +164,7 @@ func TestWithRequest(t *testing.T) {
 			stream: &mockTransportStream{method: "/atlas.example.PetStore/ListPets"},
 			appID:  "ShoppingMall",
 			expected: []*pdp.Attribute{
-				{Id: "operation", Type: "string", Value: "PetStore.ListPets"},
+				{Id: "endpoint", Type: "string", Value: "PetStore.ListPets"},
 				{Id: "application", Type: "string", Value: "shoppingmall"},
 			},
 			err: nil,
@@ -161,7 +173,7 @@ func TestWithRequest(t *testing.T) {
 			stream: &mockTransportStream{method: "/PetStore/ListPets"},
 			appID:  "",
 			expected: []*pdp.Attribute{
-				{Id: "operation", Type: "string", Value: "PetStore.ListPets"},
+				{Id: "endpoint", Type: "string", Value: "PetStore.ListPets"},
 				{Id: "application", Type: "string", Value: "default"},
 			},
 			err: nil,


### PR DESCRIPTION
# AuthZ Interceptor Update

The authorization middleware needs to be updated to reflect the latest backward incompatible changes to the authorization service. Here are the main changes I've added in this pull request.

**Changes to AuthZ Lexicon**

The `operation` keyword has been changed to `endpoint` in the authorization service, so I've added that same change to the middleware.

**Multitenancy Hack 😢**

Due to the nature of Kubernetes, all resources (deployments, services, pods, and even custom resources) must have lowercase values. The authorization service leverages custom resource definitions to represent the multitenant field, so it uses `account` instead.

As a hacky and hopefully non-permanant solution, the `MultiTenancyField` is mapped `account` before a request to Themis is made.

@markinos Has more familiarity with the multitenant constraint, so feel free to direct your questions to him.