### PR TITLE
Add toolkit support for integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,16 @@ sudo: required
 services:
   - docker
 go:
-  - 1.8
-  - 1.9
+  - "1.9"
   - "1.10"
+
+env:
+  - DEP_VERSION="0.4.1"
+
+before_install:
+  # add dep for dependency management
+  - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
+  - chmod +x $GOPATH/bin/dep
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -4,32 +4,22 @@ REPO := github.com/infobloxopen/atlas-app-toolkit
 # Build directory absolute path.
 PROJECT_ROOT = $(CURDIR)
 
-# Utility docker image to build Go binaries
-# https://github.com/infobloxopen/buildtool
-BUILDTOOL_IMAGE := infoblox/buildtool:v8
-
 # Utility docker image to generate Go files from .proto definition.
 # https://github.com/infobloxopen/atlas-gentool
 GENTOOL_IMAGE := infoblox/atlas-gentool:v3
-
-BUILDER :=  docker run --rm -v $(PROJECT_ROOT):/go/src/$(REPO) -w /go/src/$(REPO) $(BUILDTOOL_IMAGE)
-# Set BUILD_TYPE environment variable to "local" in order to use local go instance instead of buildtool
-ifeq ($(BUILD_TYPE), local)
-BUILDER :=
-endif
 
 .PHONY: default
 default: test
 
 test: check-fmt vendor
-	$(BUILDER) go test -cover ./...
+	go test -cover ./...
 
 .PHONY: vendor
 vendor:
-	$(BUILDER) dep ensure
+	dep ensure
 
 check-fmt:
-	test -z `$(BUILDER) go fmt ./...`
+	test -z `go fmt ./...`
 
 .gen-op:
 	docker run --rm -v $(PROJECT_ROOT):/go/src/$(REPO) $(GENTOOL_IMAGE) \

--- a/integration/exec.go
+++ b/integration/exec.go
@@ -1,0 +1,69 @@
+package integration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// RunBinary runs a target binary with a set of arguments provided by the user
+func RunBinary(binPath string, args ...string) (func(), error) {
+	abs, err := filepath.Abs(binPath)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, abs, args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return cancel, nil
+}
+
+// BuildSource builds a target Go package and gives the resulting binary
+// some user-defined name
+func BuildGoSource(packagePath, output string) (func() error, error) {
+	cmdBuild := exec.Command("go", "build", "-o", output, packagePath)
+	if out, err := cmdBuild.CombinedOutput(); err != nil {
+		return nil, errors.New(fmt.Sprintf("unable to build package: %v (%s)",
+			err, string(out),
+		))
+	}
+	return func() error {
+		return os.Remove(output)
+	}, nil
+}
+
+// RunContainer launches a detached docker container on the host machine. It
+// takes an image name, a list of "docker run" arguments, and a list of
+// arguments that get passed to the container runtime
+func RunContainer(image string, dockerArgs, runtimeArgs []string) (func() error, error) {
+	// build a list of args to pass to cmd.Exec
+	execDocker := append([]string{"docker", "run", "-d"}, dockerArgs...)
+	execRuntime := append([]string{image}, runtimeArgs...)
+	execDocker = append(execDocker, execRuntime...)
+	// launch the container
+	out, err := exec.Command(execDocker[0], execDocker[1:]...).CombinedOutput()
+	if err != nil {
+		return nil, errors.New(
+			fmt.Sprintf("%s: %s", err.Error(), string(out)),
+		)
+	}
+	// get the uuid from the container after it starts. this gets used to kill
+	// the container
+	var uuid string
+	if split := strings.Split(string(out), "\n"); len(split) == 0 {
+		return nil, errors.New("unable to get container uuid")
+	} else {
+		uuid = split[0]
+	}
+	return func() error {
+		return exec.Command("docker", "kill", uuid).Run()
+	}, nil
+}

--- a/integration/exec.go
+++ b/integration/exec.go
@@ -21,6 +21,7 @@ func RunBinary(binPath string, args ...string) (func(), error) {
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	if err := cmd.Start(); err != nil {
+		cancel()
 		return nil, err
 	}
 	return cancel, nil

--- a/integration/grpc.go
+++ b/integration/grpc.go
@@ -1,0 +1,28 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"google.golang.org/grpc/metadata"
+)
+
+// AppendTokenToOutgoingContext adds an authorization token to the gRPC
+// request context metadata. The user must provide a token field name like "token"
+// or "bearer"
+func AppendTokenToOutgoingContext(ctx context.Context, fieldName, token string) context.Context {
+	c := metadata.AppendToOutgoingContext(
+		ctx, "Authorization", fmt.Sprintf("%s %s", fieldName, token),
+	)
+	return c
+}
+
+// DefaultContext returns a context that has a jwt for basic testing purposes
+func StandardTestingContext() (context.Context, error) {
+	token, err := MakeTestJWT(jwt.SigningMethodHS256, StandardClaims)
+	if err != nil {
+		return nil, err
+	}
+	return AppendTokenToOutgoingContext(context.Background(), "token", token), nil
+}

--- a/integration/grpc.go
+++ b/integration/grpc.go
@@ -10,7 +10,7 @@ import (
 
 // AppendTokenToOutgoingContext adds an authorization token to the gRPC
 // request context metadata. The user must provide a token field name like "token"
-// or "bearer"
+// or "bearer" to this function. It is intended specifically for gRPC testing.
 func AppendTokenToOutgoingContext(ctx context.Context, fieldName, token string) context.Context {
 	c := metadata.AppendToOutgoingContext(
 		ctx, "Authorization", fmt.Sprintf("%s %s", fieldName, token),
@@ -18,7 +18,8 @@ func AppendTokenToOutgoingContext(ctx context.Context, fieldName, token string) 
 	return c
 }
 
-// DefaultContext returns a context that has a jwt for basic testing purposes
+// StandardTestingContext returns an outgoing request context that includes the
+// standard test JWT. It is intended specifically for gRPC testing.
 func StandardTestingContext() (context.Context, error) {
 	token, err := MakeTestJWT(jwt.SigningMethodHS256, StandardClaims)
 	if err != nil {

--- a/integration/grpc_test.go
+++ b/integration/grpc_test.go
@@ -1,0 +1,43 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestAppendTokenToOutgoingContext(t *testing.T) {
+	token, err := MakeTestJWT(
+		jwt.SigningMethodHS256, jwt.MapClaims{
+			"test-key": "test-value",
+		},
+	)
+	if err != nil {
+		t.Fatalf("unable to make test token: %v", err)
+	}
+	ctx := AppendTokenToOutgoingContext(context.Background(), "Bearer", token)
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		t.Fatal("unable to get metadata from context")
+	}
+	if md["authorization"][0] != fmt.Sprintf("Bearer %s", token) {
+		t.Fatalf("context does not contain token in metadata")
+	}
+}
+
+func TestStandardTestingContext(t *testing.T) {
+	ctx, err := StandardTestingContext()
+	if err != nil {
+		t.Fatalf("unexpected error when getting standard context: %v", err)
+	}
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		t.Fatal("unable to get metadata from context")
+	}
+	if md["authorization"][0] != fmt.Sprintf("token %s", standardToken) {
+		t.Fatalf("context does not contain token in metadata")
+	}
+}

--- a/integration/http.go
+++ b/integration/http.go
@@ -1,0 +1,28 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// MakeStandardRequest issues an HTTP request a specific endpoint with Atlas-specific
+// request data (e.g. the authorization token)
+func MakeStandardRequest(method, url string, payload interface{}) (*http.Response, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(method, url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	token, err := StandardTestJWT()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("%s %s", "token", token))
+	client := http.Client{}
+	return client.Do(req)
+}

--- a/integration/http.go
+++ b/integration/http.go
@@ -9,7 +9,7 @@ import (
 
 // MakeStandardRequest issues an HTTP request a specific endpoint with Atlas-specific
 // request data (e.g. the authorization token)
-func MakeStandardRequest(method, url string, payload interface{}) (*http.Response, error) {
+func MakeStandardRequest(method, url string, payload interface{}) (*http.Request, error) {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
@@ -23,6 +23,5 @@ func MakeStandardRequest(method, url string, payload interface{}) (*http.Respons
 		return nil, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("%s %s", "token", token))
-	client := http.Client{}
-	return client.Do(req)
+	return req, nil
 }

--- a/integration/http_test.go
+++ b/integration/http_test.go
@@ -1,0 +1,74 @@
+package integration
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMakeStandardRequest(t *testing.T) {
+	var tests = []struct {
+		name    string
+		method  string
+		payload interface{}
+		handler http.Handler
+		err     error
+	}{
+		{
+			name:    "check JWT presence in GET request",
+			method:  http.MethodGet,
+			payload: nil,
+			handler: http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					authHeader := r.Header.Get("Authorization")
+					if expected := fmt.Sprintf(
+						"%s %s", "token", standardToken,
+					); expected != authHeader {
+						t.Error("token missing in standard request")
+					}
+				},
+			),
+			err: nil,
+		},
+		{
+			name:    "check JSON payload in POST request",
+			method:  http.MethodPost,
+			payload: map[string]string{"test-key": "test-value"},
+			handler: http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					body := make(map[string]string)
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Fatalf("unable to decode json payload: %v", err)
+					}
+					if value, ok := body["test-key"]; !ok || value != "test-value" {
+						t.Errorf("unexpected json payload in request body: %v", body)
+					}
+				},
+			),
+			err: nil,
+		},
+		{
+			name:    "check invalid JSON payload with unsupported type",
+			method:  "not-an-http-verb",
+			payload: nil,
+			handler: http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {},
+			),
+			err: errors.New("net/http: invalid method"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testServer := httptest.NewServer(test.handler)
+			defer testServer.Close()
+			if _, err := MakeStandardRequest(
+				test.method, testServer.URL, test.payload,
+			); err != nil && test.err == nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/integration/http_test.go
+++ b/integration/http_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestMakeStandardRequest(t *testing.T) {
+	client := http.Client{}
 	var tests = []struct {
 		name    string
 		method  string
@@ -64,11 +65,13 @@ func TestMakeStandardRequest(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			testServer := httptest.NewServer(test.handler)
 			defer testServer.Close()
-			if _, err := MakeStandardRequest(
+			req, err := MakeStandardRequest(
 				test.method, testServer.URL, test.payload,
-			); err != nil && test.err == nil {
+			)
+			if err != nil && test.err == nil {
 				t.Errorf("unexpected error: %v", err)
 			}
+			client.Do(req)
 		})
 	}
 }

--- a/integration/jwt.go
+++ b/integration/jwt.go
@@ -1,0 +1,33 @@
+package integration
+
+import (
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/infobloxopen/atlas-app-toolkit/auth"
+)
+
+const (
+	// TestSecret dummy secret used for signing test JWTs
+	TestSecret = "some-secret-123"
+)
+
+var (
+	// DefaultClaims is the standard payload inside a test JWT
+	StandardClaims = jwt.MapClaims{
+		auth.MultiTenancyField: "TestAccount",
+	}
+)
+
+// MakeToken generates a token string based on the given jwt claims
+func MakeTestJWT(method jwt.SigningMethod, claims jwt.Claims) (string, error) {
+	token, err := jwt.NewWithClaims(
+		method, claims,
+	).SignedString([]byte(TestSecret))
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+func StandardTestJWT() (string, error) {
+	return MakeTestJWT(jwt.SigningMethodHS256, StandardClaims)
+}

--- a/integration/jwt.go
+++ b/integration/jwt.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	// TestSecret dummy secret used for signing test JWTs
-	TestSecret = "some-secret-123"
+	// testSecret is a dummy secret used for signing test JWTs
+	testSecret = "some-secret-123"
 )
 
 var (
@@ -21,7 +21,7 @@ var (
 func MakeTestJWT(method jwt.SigningMethod, claims jwt.Claims) (string, error) {
 	token, err := jwt.NewWithClaims(
 		method, claims,
-	).SignedString([]byte(TestSecret))
+	).SignedString([]byte(testSecret))
 	if err != nil {
 		return "", err
 	}

--- a/integration/jwt.go
+++ b/integration/jwt.go
@@ -11,13 +11,13 @@ const (
 )
 
 var (
-	// DefaultClaims is the standard payload inside a test JWT
+	// StandardClaims is the standard payload inside a test JWT
 	StandardClaims = jwt.MapClaims{
 		auth.MultiTenancyField: "TestAccount",
 	}
 )
 
-// MakeToken generates a token string based on the given jwt claims
+// MakeTestJWT generates a token string based on the given JWT claims
 func MakeTestJWT(method jwt.SigningMethod, claims jwt.Claims) (string, error) {
 	token, err := jwt.NewWithClaims(
 		method, claims,
@@ -28,6 +28,7 @@ func MakeTestJWT(method jwt.SigningMethod, claims jwt.Claims) (string, error) {
 	return token, nil
 }
 
+// StandardTestJWT builds a JWT with the standard test claims in the JWT payload
 func StandardTestJWT() (string, error) {
 	return MakeTestJWT(jwt.SigningMethodHS256, StandardClaims)
 }

--- a/integration/jwt_test.go
+++ b/integration/jwt_test.go
@@ -1,0 +1,83 @@
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	jwt "github.com/dgrijalva/jwt-go"
+)
+
+var (
+	// break apart the token so it isn't one huge line
+	standardToken = fmt.Sprintf("%s%s%s",
+		"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.",
+		"eyJBY2NvdW50SUQiOiJUZXN0QWNjb3VudCJ9.",
+		"Qt7yYMcN2rEYavhgbhVMV762RBmAVUd32mW_VDIAKvM",
+	)
+)
+
+// DefaultContext returns a context that has a jwt for basic testing purposes
+func TestMakeTestJWT(t *testing.T) {
+	var tests = []struct {
+		name          string
+		expected      string
+		signingMethod jwt.SigningMethod
+		claims        jwt.Claims
+		err           error
+	}{
+		{
+			"standard claims and signing method",
+			standardToken,
+			jwt.SigningMethodHS256,
+			StandardClaims,
+			nil,
+		},
+		{
+			"force error when signing",
+			"",
+			mockSigningMethod{},
+			StandardClaims,
+			jwt.ErrInvalidKey,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			token, err := MakeTestJWT(test.signingMethod, test.claims)
+			if token != test.expected {
+				t.Errorf("unexpected value when building test token: have %s, expected %s",
+					token, test.expected,
+				)
+			}
+			if err != test.err {
+				t.Errorf("unexpected error: have %s, expected %s",
+					err, test.err,
+				)
+			}
+		})
+	}
+}
+
+func TestStandardTestJWT(t *testing.T) {
+	t.Run("check test token", func(t *testing.T) {
+		token, err := StandardTestJWT()
+		if err != nil {
+			t.Fatalf("unexpected error when building standard test token: %v", err)
+		}
+		if token != standardToken {
+			t.Errorf("unexpected token value: have %s, expected %s",
+				token, standardToken,
+			)
+		}
+	})
+}
+
+type mockSigningMethod struct{}
+
+func (mockSigningMethod) Verify(string, string, interface{}) error { return nil }
+
+func (mockSigningMethod) Sign(string, interface{}) (string, error) {
+	// return an arbitrary signing-related error
+	return "", jwt.ErrInvalidKey
+}
+
+func (mockSigningMethod) Alg() string { return "" }

--- a/integration/network.go
+++ b/integration/network.go
@@ -45,3 +45,8 @@ func GetOpenPortInRange(lowerBound, upperBound int) (int, error) {
 	}
 	return -1, errPortNotFound
 }
+
+// GetOpenPort searches for an open port on the host
+func GetOpenPort() (int, error) {
+	return GetOpenPortInRange(portRangeMin, portRangeMax)
+}

--- a/integration/network.go
+++ b/integration/network.go
@@ -1,0 +1,47 @@
+package integration
+
+import (
+	"fmt"
+	"net"
+)
+
+const (
+	portRangeMin = 0
+	portRangeMax = 65535
+)
+
+var (
+	errPortMax = portError{
+		message: fmt.Sprintf("port cannot be greater than %d", portRangeMax),
+	}
+	errPortMin = portError{
+		message: fmt.Sprintf("port cannot be less than %d", portRangeMin),
+	}
+	errPortNotFound = portError{
+		message: fmt.Sprintf("no open port found %d", portRangeMin),
+	}
+)
+
+type portError struct{ message string }
+
+// Error returns a string with the port-related error message
+func (p portError) Error() string {
+	return fmt.Sprintf("port discovery error: %s", p.message)
+}
+
+// GetOpenPortInRange finds the first unused port within specific range
+func GetOpenPortInRange(lowerBound, upperBound int) (int, error) {
+	if lowerBound < portRangeMin {
+		return -1, errPortMin
+	}
+	for lowerBound <= portRangeMax && lowerBound <= upperBound {
+		if _, err := net.Dial("tcp", fmt.Sprintf(":%d", lowerBound)); err != nil {
+			return lowerBound, nil
+		}
+		lowerBound++
+	}
+	if upperBound > portRangeMax {
+		return -1, errPortMax
+	}
+	return -1, errPortNotFound
+}

--- a/integration/network_test.go
+++ b/integration/network_test.go
@@ -1,0 +1,42 @@
+package integration
+
+import (
+	"testing"
+)
+
+func TestGetOpenPortInRange(t *testing.T) {
+	var tests = []struct {
+		name     string
+		minRange int
+		maxRange int
+		err      error
+	}{
+		{
+			name:     "negative port range",
+			minRange: -1,
+			maxRange: 0,
+			err:      errPortMin,
+		},
+		{
+			name:     "exceed maximum port upperbound",
+			minRange: portRangeMax + 1,
+			maxRange: portRangeMax + 10,
+			err:      errPortMax,
+		},
+		{
+			name:     "exceed specified port uppercbound",
+			minRange: 20,
+			maxRange: 10,
+			err:      errPortNotFound,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := GetOpenPortInRange(test.minRange, test.maxRange); err != test.err {
+				t.Errorf("unexpected error when getting open port: have %v; expected %v",
+					err, test.err,
+				)
+			}
+		})
+	}
+}

--- a/integration/postgres.go
+++ b/integration/postgres.go
@@ -188,9 +188,7 @@ func WithMigrateFunction(migrateFunction func(sql.DB) error) func(*testPostgresD
 	}
 }
 
-// WithMigrateFunction is used to rebuild the test Postgres database on a
-// per-test basis. Whenever the database is reset with the Reset() function, the
-// migrate function will rebuild the tables.
+// WithTimeout is used to specify a connection timeout to the database
 func WithTimeout(timeout time.Duration) func(*testPostgresDB) {
 	return func(db *testPostgresDB) {
 		db.timeout = timeout

--- a/integration/postgres.go
+++ b/integration/postgres.go
@@ -1,0 +1,198 @@
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+var (
+	errConnectionTimeout = testDatabaseError{
+		message: "database connection timed out",
+	}
+)
+
+type testDatabaseError struct{ message string }
+
+func (e testDatabaseError) Error() string {
+	return fmt.Sprintf("testing database error: %s", e.message)
+}
+
+type testPostgresDB struct {
+	host            string
+	port            int
+	dbName          string
+	dbUser          string
+	dbPassword      string
+	dbVersion       string
+	migrateFunction func(sql.DB) error
+	timeout         time.Duration
+}
+
+// NewTestPostgresDB returns a test postgres database that
+// the functional options that have been provided by the caller
+func NewTestPostgresDB(opts ...option) (testPostgresDB, error) {
+	port, err := GetOpenPortInRange(35000, portRangeMax)
+	if err != nil {
+		return testPostgresDB{}, err
+	}
+	db := testPostgresDB{
+		port:       port,
+		dbName:     "test-postgres-db",
+		dbUser:     "postgres",
+		dbPassword: "postgres",
+		dbVersion:  "latest",
+		timeout:    time.Second * 10,
+	}
+	for _, opt := range opts {
+		opt(&db)
+	}
+	return db, nil
+}
+
+// Reset drops all the tables in a test database and regenerates them by
+// running migrations. If a migration function has not been specified, then the
+// tables are dropped but not regenerated
+func (db testPostgresDB) Reset() error {
+	dbSQL, err := sql.Open("postgres", db.GetDSN())
+	if err != nil {
+		return err
+	}
+	defer dbSQL.Close()
+	resetQuery := "DROP SCHEMA public CASCADE;" +
+		"CREATE SCHEMA public;" +
+		"GRANT ALL ON SCHEMA public TO postgres;" +
+		"GRANT ALL ON SCHEMA public TO public;"
+	// drop all the tables in the test database
+	if _, err := dbSQL.Exec(resetQuery); err != nil {
+		return err
+	}
+	// run migrations if a migration function has exists
+	if db.migrateFunction != nil {
+		if err := db.migrateFunction(*dbSQL); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RunAsDockerContainer spins-up a Postgres database server as a Docker
+// container. The test Postgres database will run inside this Docker container.
+func (db testPostgresDB) RunAsDockerContainer(containerName string) (func() error, error) {
+	cleanup, err := RunContainer(
+		// define the postgres image version
+		fmt.Sprintf("postgres:%s", db.dbVersion),
+		// define the arguments to docker
+		[]string{
+			fmt.Sprintf("--name=%s", containerName),
+			fmt.Sprintf("--publish=%d:5432", db.port),
+			fmt.Sprintf("--env=POSTGRES_DB=%s", db.dbName),
+			fmt.Sprintf("--env=POSTGRES_PASSWORD=%s", db.dbPassword),
+			fmt.Sprintf("--env=POSTGRES_USER=%s", db.dbUser),
+			"--detach",
+			"--rm",
+		},
+		// define the runtime arguments to postgres
+		[]string{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := db.checkConnection(); err != nil {
+		cleanup()
+		return nil, err
+	}
+	return cleanup, nil
+}
+
+func (db testPostgresDB) checkConnection() error {
+	ctx, cancel := context.WithTimeout(context.Background(), db.timeout)
+	defer cancel()
+	errStream := make(chan error)
+	go func() {
+		for {
+			select {
+			case <-time.After(500 * time.Millisecond):
+				driver, _ := sql.Open("postgres", db.GetDSN())
+				if err := driver.Ping(); err == nil {
+					errStream <- nil
+					return
+				}
+			case <-ctx.Done():
+				errStream <- errConnectionTimeout
+			}
+		}
+	}()
+	if err := <-errStream; err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetDSN returns the database connection string for the test Postgres database
+func (db testPostgresDB) GetDSN() string {
+	return fmt.Sprintf(
+		"host=localhost port=%d user=%s password=%s sslmode=disable dbname=%s",
+		db.port, db.dbUser, db.dbPassword, db.dbName,
+	)
+}
+
+type option func(*testPostgresDB)
+
+// WithName is used to specify the name of the test Postgres database. By default
+// the database name is "test-postgres-db"
+func WithName(name string) func(*testPostgresDB) {
+	return func(db *testPostgresDB) {
+		db.dbName = name
+	}
+}
+
+// WithPort is used to specify the port of the test Postgres database. By
+// default, the test database will find the first open port in the 35000+ range
+func WithPort(port int) func(*testPostgresDB) {
+	return func(db *testPostgresDB) {
+		db.port = port
+	}
+}
+
+// WithUser is used to specify the name of the Postgres user that owns the
+// test database
+func WithUser(user string) func(*testPostgresDB) {
+	return func(db *testPostgresDB) {
+		db.dbUser = user
+	}
+}
+
+// WithPassword is used to specify the password of the test Postgres database
+func WithPassword(password string) func(*testPostgresDB) {
+	return func(db *testPostgresDB) {
+		db.dbPassword = password
+	}
+}
+
+// WithVersion is used to specify the version of the test Postgres database. By
+// default the version is "latest"
+func WithVersion(version string) func(*testPostgresDB) {
+	return func(db *testPostgresDB) {
+		db.dbVersion = version
+	}
+}
+
+// WithMigrateFunction is used to rebuild the test Postgres database on a
+// per-test basis. Whenever the database is reset with the Reset() function, the
+// migrate function will rebuild the tables.
+func WithMigrateFunction(migrateFunction func(sql.DB) error) func(*testPostgresDB) {
+	return func(db *testPostgresDB) {
+		db.migrateFunction = migrateFunction
+	}
+}
+
+// WithMigrateFunction is used to rebuild the test Postgres database on a
+// per-test basis. Whenever the database is reset with the Reset() function, the
+// migrate function will rebuild the tables.
+func WithTimeout(timeout time.Duration) func(*testPostgresDB) {
+	return func(db *testPostgresDB) {
+		db.timeout = timeout
+	}
+}

--- a/integration/postgres.go
+++ b/integration/postgres.go
@@ -79,13 +79,12 @@ func (db testPostgresDB) Reset() error {
 
 // RunAsDockerContainer spins-up a Postgres database server as a Docker
 // container. The test Postgres database will run inside this Docker container.
-func (db testPostgresDB) RunAsDockerContainer(containerName string) (func() error, error) {
+func (db testPostgresDB) RunAsDockerContainer() (func() error, error) {
 	cleanup, err := RunContainer(
 		// define the postgres image version
 		fmt.Sprintf("postgres:%s", db.dbVersion),
 		// define the arguments to docker
 		[]string{
-			fmt.Sprintf("--name=%s", containerName),
 			fmt.Sprintf("--publish=%d:5432", db.port),
 			fmt.Sprintf("--env=POSTGRES_DB=%s", db.dbName),
 			fmt.Sprintf("--env=POSTGRES_PASSWORD=%s", db.dbPassword),

--- a/integration/postgres.go
+++ b/integration/postgres.go
@@ -26,7 +26,7 @@ type testPostgresDB struct {
 	dbUser          string
 	dbPassword      string
 	dbVersion       string
-	migrateFunction func(sql.DB) error
+	migrateFunction func(*sql.DB) error
 	timeout         time.Duration
 }
 
@@ -70,7 +70,7 @@ func (db testPostgresDB) Reset() error {
 	}
 	// run migrations if a migration function has exists
 	if db.migrateFunction != nil {
-		if err := db.migrateFunction(*dbSQL); err != nil {
+		if err := db.migrateFunction(dbSQL); err != nil {
 			return err
 		}
 	}
@@ -182,7 +182,7 @@ func WithVersion(version string) func(*testPostgresDB) {
 // WithMigrateFunction is used to rebuild the test Postgres database on a
 // per-test basis. Whenever the database is reset with the Reset() function, the
 // migrate function will rebuild the tables.
-func WithMigrateFunction(migrateFunction func(sql.DB) error) func(*testPostgresDB) {
+func WithMigrateFunction(migrateFunction func(*sql.DB) error) func(*testPostgresDB) {
 	return func(db *testPostgresDB) {
 		db.migrateFunction = migrateFunction
 	}

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -75,7 +75,7 @@ func TestCheckConnection(t *testing.T) {
 		t.Errorf("expected to get non-nil error")
 	}
 	db.host = "localhost"
-	rm, err := db.RunAsDockerContainer("test-postgres-container")
+	rm, err := db.RunAsDockerContainer()
 	if err != nil {
 		t.Fatalf("unable to start the database container: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestReset(t *testing.T) {
 	if err := db.Reset(); err == nil {
 		t.Errorf("expected to receive an error when resetting database")
 	}
-	rm, err := db.RunAsDockerContainer("test-postgres-container")
+	rm, err := db.RunAsDockerContainer()
 	if err != nil {
 		t.Fatalf("unable to start the database container: %v", err)
 	}

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -100,13 +100,13 @@ func TestReset(t *testing.T) {
 		t.Fatalf("unable to start the database container: %v", err)
 	}
 	defer rm()
-	db.migrateFunction = func(*sql.DB) error {
+	db.migrateUpFunction = func(*sql.DB) error {
 		return errors.New("intentional testing error")
 	}
 	if err := db.Reset(); err == nil {
 		t.Errorf("expected to receive an error when migrating database")
 	}
-	db.migrateFunction = func(*sql.DB) error {
+	db.migrateUpFunction = func(*sql.DB) error {
 		orm, err := gorm.Open("postgres", db.GetDSN())
 		if err != nil {
 			t.Errorf("unable to connect to database: %v", err)

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -100,13 +100,13 @@ func TestReset(t *testing.T) {
 		t.Fatalf("unable to start the database container: %v", err)
 	}
 	defer rm()
-	db.migrateFunction = func(sql.DB) error {
+	db.migrateFunction = func(*sql.DB) error {
 		return errors.New("intentional testing error")
 	}
 	if err := db.Reset(); err == nil {
 		t.Errorf("expected to receive an error when migrating database")
 	}
-	db.migrateFunction = func(sql.DB) error {
+	db.migrateFunction = func(*sql.DB) error {
 		orm, err := gorm.Open("postgres", db.GetDSN())
 		if err != nil {
 			t.Errorf("unable to connect to database: %v", err)

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -1,0 +1,120 @@
+package integration
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/postgres"
+)
+
+// buildDB creates a new test Postgres database and halts the test if anything
+// fails during this process
+func buildDB(t *testing.T, opts ...option) testPostgresDB {
+	db, err := NewTestPostgresDB(opts...)
+	if err != nil {
+		t.Fatalf("unable to create test postgres database")
+	}
+	return db
+}
+
+func TestGetDSN(t *testing.T) {
+	var tests = []struct {
+		name     string
+		opts     []option
+		expected string
+	}{
+		{
+			name: "vanilla test database",
+			opts: []option{
+				// test will fail if default port is taken, so the port is specified
+				WithPort(37000),
+			},
+			expected: "host=localhost port=37000 user=postgres " +
+				"password=postgres sslmode=disable dbname=test-postgres-db",
+		},
+		{
+			name: "test with all options",
+			opts: []option{
+				WithName("some-test-db"),
+				WithPort(37000),
+				WithUser("test-user"),
+				WithPassword("secret"),
+				WithVersion("9.5.13"),
+			},
+			expected: "host=localhost port=37000 user=test-user " +
+				"password=secret sslmode=disable dbname=some-test-db",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, err := NewTestPostgresDB(test.opts...)
+			if err != nil {
+				t.Fatalf("unable to build test database")
+			}
+			if dsn := db.GetDSN(); dsn != test.expected {
+				t.Errorf("unexpected database connection string: have %s; want %s",
+					dsn, test.expected,
+				)
+			}
+		})
+	}
+}
+
+func TestCheckConnection(t *testing.T) {
+	db, err := NewTestPostgresDB(
+		WithTimeout(time.Second * 5),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	db.host = "some-fake-hostname"
+	if err := db.checkConnection(); err == nil {
+		t.Errorf("expected to get non-nil error")
+	}
+	db.host = "localhost"
+	rm, err := db.RunAsDockerContainer("test-postgres-container")
+	if err != nil {
+		t.Fatalf("unable to start the database container: %v", err)
+	}
+	defer rm()
+}
+
+type testTable struct {
+	gorm.Model
+	Test string
+}
+
+func TestReset(t *testing.T) {
+	db, err := NewTestPostgresDB()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := db.Reset(); err == nil {
+		t.Errorf("expected to receive an error when resetting database")
+	}
+	rm, err := db.RunAsDockerContainer("test-postgres-container")
+	if err != nil {
+		t.Fatalf("unable to start the database container: %v", err)
+	}
+	defer rm()
+	db.migrateFunction = func(sql.DB) error {
+		return errors.New("intentional testing error")
+	}
+	if err := db.Reset(); err == nil {
+		t.Errorf("expected to receive an error when migrating database")
+	}
+	db.migrateFunction = func(sql.DB) error {
+		orm, err := gorm.Open("postgres", db.GetDSN())
+		if err != nil {
+			t.Errorf("unable to connect to database: %v", err)
+		}
+		orm.AutoMigrate(&testTable{})
+		return nil
+	}
+	if err := db.Reset(); err != nil {
+		t.Errorf("unexpected error when resetting the database: %v", err)
+	}
+}


### PR DESCRIPTION
# Integration Testing

This pull request adds support for integration testing. There are a lot of additions, but the code itself isn't hugely complicated. Here's a summary of the package and each major file within it.

**The `intergration` package**

This package provides helpers that spin-up a basic testing environment to run integration tests repeatedly and reliably. The helpers are intended to be application-agnostic and can get reused by multiple teams.

In fact, some of these helpers aren't specific to integration testing, so maybe it's worth renaming this package to something more general like `test` instead (okay, maybe's that _too_ general).

**The `exec.go` file**

Integration testing might involve creating and running a Go binary, or maybe running a container to behave as a short-lived database. This file offers basic helpers that run command-line calls for these exact purposes.

It also provides a way to stop/destroy the binaries and containers that get created during testing.

**The `grpc.go` file**

To make gRPC calls, the request context needs to include a JWT for authorization. If it doesn't, then the client will get an error message. The `grpc.go` file has some basic helpers to build a standard request context.

**The `http.go` file**

This exists for the same reason `grpc.go` does: to make it easy to repeatedly send requests that might need specific headers/metadata.

**The `jwt.go` file**

This is concerned JWT-related functionality, like creating test tokens and getting a token with "standard" fields in the payload (e.g. an `AccountID` field).

**The `postgres.go` file**

This file is mostly responsible for spinning-up a Postgres container and exposing a set of functional options to configure the database. It also provides functionality to reset the database on a per-test basis.