### PR TITLE
Remove multitenancy-related hack in JWT option

### DIFF
--- a/auth/options.go
+++ b/auth/options.go
@@ -31,12 +31,6 @@ func WithJWT(keyfunc jwt.Keyfunc) option {
 			return attributes, ErrInternal
 		}
 		for k, v := range claims {
-			// HACK: if the multi-tenancy field is included in the JWT payload, it needs
-			// to be changed to "account" because "account" is the multi-tenancy field
-			// used in the authorization service
-			if k == MultiTenancyField {
-				k = "account"
-			}
 			attr := &pdp.Attribute{Id: k, Type: "string", Value: fmt.Sprint(v)}
 			attributes = append(attributes, attr)
 		}

--- a/auth/options_test.go
+++ b/auth/options_test.go
@@ -37,18 +37,6 @@ func TestWithJWT(t *testing.T) {
 			},
 			err: nil,
 		},
-		{
-			token: makeToken(jwt.MapClaims{
-				MultiTenancyField: "TestAccount",
-			}, t),
-			expected: []*pdp.Attribute{
-				{Id: "account", Type: "string", Value: "TestAccount"},
-			},
-			keyfunc: func(token *jwt.Token) (interface{}, error) {
-				return []byte(TestSecret), nil
-			},
-			err: nil,
-		},
 		// parse and verify an invalid token
 		{
 			token: makeToken(jwt.MapClaims{


### PR DESCRIPTION
# Remove Multitenancy Hack

Due to the behavior of the authorization service and the naming restrictions of Kubernetes, @markinos  and I had to introduce a hack to get around an issue. Specifically, this issue prevented the multitenant field from having uppercase letters.

This pull request removes the hacky code that we introduced because a workaround was found in the authorization service 🎉 