### PR TITLE
Fix revision for themis

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,7 +1,7 @@
 [[constraint]]
-  branch = "master"
   name = "github.com/infobloxopen/themis"
-  
+  revision = "d62bb103665cf16dfcee5083f4557163fb7a68ff"
+
 [[constraint]]
   branch = "master"
   name = "github.com/dgrijalva/jwt-go"


### PR DESCRIPTION
Themis introduced a backward incompatible changes with their latest commit that crashed our auth interceptor.