### PR TITLE
Remove panic recoveries in interceptors

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/infobloxopen/atlas-app-toolkit/query"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
-	"google.golang.org/grpc/status"
 )
 
 // UnaryServerInterceptor returns grpc.UnaryServerInterceptor
@@ -20,14 +18,6 @@ import (
 // they defined in a request message.
 func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (res interface{}, err error) {
-		// handle panic
-		defer func() {
-			if perr := recover(); perr != nil {
-				err = status.Errorf(codes.Internal, "collection operators interceptor: %s", perr)
-				grpclog.Errorln(err)
-				res, err = nil, err
-			}
-		}()
 
 		if req == nil {
 			grpclog.Warningf("collection operator interceptor: empty request %+v", req)

--- a/requestid/interceptor.go
+++ b/requestid/interceptor.go
@@ -4,9 +4,6 @@ import (
 	"context"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/grpclog"
-	"google.golang.org/grpc/status"
 )
 
 // UnaryServerInterceptor returns grpc.UnaryServerInterceptor
@@ -18,14 +15,6 @@ import (
 // they defined in a testRequest message else creates a new one.
 func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (res interface{}, err error) {
-		// handle panic
-		defer func() {
-			if perr := recover(); perr != nil {
-				err = status.Errorf(codes.Internal, "request id interceptor: %s", perr)
-				grpclog.Errorln(err)
-				res, err = nil, err
-			}
-		}()
 
 		reqID := handleRequestID(ctx)
 		// add request id to logger

--- a/requestid/interceptor_test.go
+++ b/requestid/interceptor_test.go
@@ -50,14 +50,3 @@ func TestUnaryServerInterceptorWithDummyRequestId(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
-
-func TestUnaryServerInterceptorPanic(t *testing.T) {
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		panic("TestUnaryServerInterceptorPanic raised panic")
-	}
-	ctx := DummyContextWithServerTransportStream()
-	_, err := UnaryServerInterceptor()(ctx, testRequest{}, nil, handler)
-	if err == nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}


### PR DESCRIPTION
Removes the recovers from the toolkit request-id and collection operator middlewares.

a. They should not be catching panics generated in app or other middleware code. 
b. They should also not be generating any panics of their own to be recovering from.
Given points a & b, this code is unnecessary (and sometimes a nuisance when it intercepts legitimate panics without printing the stack trace).