### PR TITLE
Constructor for Transaction struct

### DIFF
--- a/gorm/transaction.go
+++ b/gorm/transaction.go
@@ -47,6 +47,10 @@ type Transaction struct {
 	afterCommitHook []func(context.Context)
 }
 
+func NewTransaction(db *gorm.DB) Transaction {
+	return Transaction{parent: db}
+}
+
 func (t *Transaction) AddAfterCommitHook(hooks ...func(context.Context)) {
 	t.afterCommitHook = append(t.afterCommitHook, hooks...)
 }


### PR DESCRIPTION
Create NewTransaction() function to instantiate a Transaction struct with the parent db provided.