### PR TITLE
Change default token type for authorization

### DIFF
--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -19,7 +19,7 @@ const (
 
 	// DefaultTokenType is the name of the authorization token (e.g. "Bearer"
 	// or "token")
-	DefaultTokenType = "token"
+	DefaultTokenType = "Bearer"
 )
 
 var (


### PR DESCRIPTION
# Change Default Token Type

The token that gets passed to applications will be a `Bearer` token, not a `token` type. This will be the general case for each application, so it makes sense to update the default behavior accordingly.

While this isn't a breaking change, it might impact toolkit users. For example, in the contacts application, our [example requests](https://github.com/infobloxopen/atlas-contacts-app#try-atlas-contacts-app) use `token` and not `Bearer` so the documentation will need to get updated to reflect this change.