### PR TITLE
make parameter checks more permissive for MergeWithMask

### DIFF
--- a/gorm/fieldmask.go
+++ b/gorm/fieldmask.go
@@ -12,11 +12,11 @@ import (
 // MergeWithMask will take the fields of `source` that are included as
 // paths in `mask` and write them to the corresponding fields of `dest`
 func MergeWithMask(source, dest interface{}, mask *fieldmask.FieldMask) error {
-	if source == nil {
-		return nil
-	}
 	if mask == nil || len(mask.Paths) == 0 {
 		return nil
+	}
+	if source == nil {
+		return errors.New("Source object is nil")
 	}
 	if dest == nil {
 		return errors.New("Destination object is nil")

--- a/gorm/fieldmask.go
+++ b/gorm/fieldmask.go
@@ -13,13 +13,13 @@ import (
 // paths in `mask` and write them to the corresponding fields of `dest`
 func MergeWithMask(source, dest interface{}, mask *fieldmask.FieldMask) error {
 	if source == nil {
-		return errors.New("Source object is nil")
+		return nil
+	}
+	if mask == nil || len(mask.Paths) == 0 {
+		return nil
 	}
 	if dest == nil {
 		return errors.New("Destination object is nil")
-	}
-	if mask == nil {
-		return errors.New("FieldMask is nil")
 	}
 	if reflect.TypeOf(source) != reflect.TypeOf(dest) {
 		return errors.New("Types of source and destination objects do not match")

--- a/gorm/fieldmask_test.go
+++ b/gorm/fieldmask_test.go
@@ -41,12 +41,18 @@ func TestMergeWithMask(t *testing.T) {
 	err = MergeWithMask(source, dest, &field_mask.FieldMask{Paths: []string{"FieldB.FieldDNE", "FieldA.FieldTwo"}})
 	assert.Equal(t, errors.New("Field path \"FieldB.FieldDNE\" doesn't exist in type *gorm.topTest"), err)
 
-	err = MergeWithMask(nil, nil, nil)
-	assert.Equal(t, errors.New("Source object is nil"), err)
-	err = MergeWithMask(source, nil, nil)
+	for _, fm := range []*field_mask.FieldMask{nil, {}} {
+		err = MergeWithMask(nil, nil, fm)
+		assert.Nil(t, err)
+		err = MergeWithMask(nil, dest, fm)
+		assert.Nil(t, err)
+		err = MergeWithMask(source, nil, fm)
+		assert.Nil(t, err)
+		err = MergeWithMask(source, dest.FieldA, fm)
+		assert.Nil(t, err)
+	}
+	err = MergeWithMask(source, nil, &field_mask.FieldMask{Paths: []string{"FieldB"}})
 	assert.Equal(t, errors.New("Destination object is nil"), err)
-	err = MergeWithMask(source, dest, nil)
-	assert.Equal(t, errors.New("FieldMask is nil"), err)
-	err = MergeWithMask(source, dest.FieldA, &field_mask.FieldMask{})
+	err = MergeWithMask(source, dest.FieldA, &field_mask.FieldMask{Paths: []string{"FieldB"}})
 	assert.Equal(t, errors.New("Types of source and destination objects do not match"), err)
 }

--- a/gorm/fieldmask_test.go
+++ b/gorm/fieldmask_test.go
@@ -41,6 +41,9 @@ func TestMergeWithMask(t *testing.T) {
 	err = MergeWithMask(source, dest, &field_mask.FieldMask{Paths: []string{"FieldB.FieldDNE", "FieldA.FieldTwo"}})
 	assert.Equal(t, errors.New("Field path \"FieldB.FieldDNE\" doesn't exist in type *gorm.topTest"), err)
 
+	err = MergeWithMask(nil, dest, &field_mask.FieldMask{Paths: []string{"FieldB.FieldDNE"}})
+	assert.Equal(t, errors.New("Source object is nil"), err)
+
 	for _, fm := range []*field_mask.FieldMask{nil, {}} {
 		err = MergeWithMask(nil, nil, fm)
 		assert.Nil(t, err)


### PR DESCRIPTION
The idea here is to allow scenarios where the result of the merge would end up with the destination object being unchanged