### PR TITLE
Fix bug that can cause field masks to get mangled

### DIFF
--- a/gateway/field_presence.go
+++ b/gateway/field_presence.go
@@ -54,9 +54,13 @@ func NewPresenceAnnotator(methods ...string) func(context.Context, *http.Request
 			item := queue[0]
 			queue = queue[1:]
 			if m, ok := item.node.(map[string]interface{}); ok {
+				l := len(item.path)
 				// if the item is an object, then enqueue all of its children
 				for k, v := range m {
-					queue = append(queue, pathItem{path: append(item.path, generator.CamelCase(k)), node: v})
+					newPath := make([]string, l+1)
+					copy(newPath, item.path)
+					newPath[l] = generator.CamelCase(k)
+					queue = append(queue, pathItem{path: newPath, node: v})
 				}
 			} else if len(item.path) > 0 {
 				// otherwise, it's a leaf node so print its path

--- a/gateway/field_presence_test.go
+++ b/gateway/field_presence_test.go
@@ -20,6 +20,27 @@ func TestAnnotator(t *testing.T) {
 		`{}`: metadata.MD{},
 		`{`:  nil,
 		`{"one":{"two":"a", "three":[]}, "four": 5}`: {fieldPresenceMetaKey: []string{"Four", "One.Two", "One.Three"}},
+		`{
+  "name": "atlas",
+  "burden": {
+    "duration": "forever",
+    "weight": "earth",
+    "breaks": [],
+    "replacements": {
+			"hero": {
+	        "name": "hercules",
+	        "duration": "temporary",
+					"lineage": {
+						"mother": "alcmena",
+						"father": "zeus"
+					}
+	      },
+			"mortals": []
+		}
+  }
+}`: {fieldPresenceMetaKey: []string{"Name", "Burden.Duration", "Burden.Weight",
+			"Burden.Breaks", "Burden.Replacements.Hero.Name", "Burden.Replacements.Hero.Duration",
+			"Burden.Replacements.Hero.Lineage.Mother", "Burden.Replacements.Hero.Lineage.Father", "Burden.Replacements.Mortals"}},
 	} {
 		postReq := &http.Request{
 			Method: "POST",


### PR DESCRIPTION
Sneaky bug is caused because underlying array of slice may or may not be deep copied during an append. This can cause later appends to overwrite the fields of earlier appends. Tests didn't detect because either structures weren't deep enough or didn't branch enough.