### PR TITLE
Change multi-tenant identifier from AccountID to account_id

### DIFF
--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -59,6 +59,9 @@ func GetAccountID(ctx context.Context, keyfunc jwt.Keyfunc) (string, error) {
 // because it has been checked previously in the stack. More information
 // here: https://godoc.org/github.com/dgrijalva/jwt-go#Parser.ParseUnverified
 func getToken(ctx context.Context, tokenField string, keyfunc jwt.Keyfunc) (jwt.Token, error) {
+	if ctx == nil {
+		return jwt.Token{}, ErrUnauthorized
+	}
 	tokenStr, err := grpc_auth.AuthFromMD(ctx, tokenField)
 	if err != nil {
 		return jwt.Token{}, ErrUnauthorized

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -22,6 +22,12 @@ var (
 	errMissingField     = errors.New("unable to get field from token")
 	errMissingToken     = errors.New("unable to get token from context")
 	errInvalidAssertion = errors.New("unable to assert value as jwt.MapClaims")
+
+	// multiTenancyVariants all possible multi-tenant names
+	multiTenancyVariants = []string{
+		MultiTenancyField,
+		"AccountID",
+	}
 )
 
 // GetJWTFieldWithTokenType gets the JWT from a context and returns the
@@ -51,7 +57,12 @@ func GetJWTField(ctx context.Context, tokenField string, keyfunc jwt.Keyfunc) (s
 
 // GetAccountID gets the JWT from a context and returns the AccountID field
 func GetAccountID(ctx context.Context, keyfunc jwt.Keyfunc) (string, error) {
-	return GetJWTField(ctx, MultiTenancyField, keyfunc)
+	for _, tenantField := range multiTenancyVariants {
+		if val, err := GetJWTField(ctx, tenantField, keyfunc); err == nil {
+			return val, nil
+		}
+	}
+	return "", errMissingField
 }
 
 // getToken parses the token into a jwt.Token type from the grpc metadata.

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -10,12 +10,8 @@ import (
 )
 
 const (
-	// TODO: Field is tentatively called "AccountID" but will probably need to be
-	// changed. We don't know what the JWT will look like, so we're giving it our
-	// best guess for the time being.
-
 	// MultiTenancyField the field name for a specific tenant
-	MultiTenancyField = "AccountID"
+	MultiTenancyField = "account_id"
 
 	// DefaultTokenType is the name of the authorization token (e.g. "Bearer"
 	// or "token")

--- a/auth/jwt_test.go
+++ b/auth/jwt_test.go
@@ -16,45 +16,70 @@ const (
 
 func TestGetJWTFieldWithTokenType(t *testing.T) {
 	var jwtFieldTests = []struct {
-		claims    jwt.MapClaims
-		tokenType string
-		field     string
-		expected  string
-		err       error
+		claims         jwt.MapClaims
+		contextFactory func(t *testing.T) context.Context
+		tokenType      string
+		field          string
+		expected       string
+		err            error
 	}{
 		{
-			claims:    jwt.MapClaims{"some-field": "id-abc-123"},
-			tokenType: "token",
+			contextFactory: func(t *testing.T) context.Context {
+				token := makeToken(jwt.MapClaims{"some-field": "id-abc-123"}, t)
+				ctx, err := contextWithToken(token, "Bearer")
+				if err != nil {
+					t.Fatalf("Error when building request context: %v", err)
+				}
+				return ctx
+			},
+			tokenType: "Bearer",
 			field:     "some-field",
 			expected:  "id-abc-123",
 			err:       nil,
 		},
 		{
-			claims:    jwt.MapClaims{"some-field": "id-abc-123"},
+			contextFactory: func(t *testing.T) context.Context {
+				token := makeToken(jwt.MapClaims{"some-field": "id-abc-123"}, t)
+				ctx, err := contextWithToken(token, "Bearer")
+				if err != nil {
+					t.Fatalf("Error when building request context: %v", err)
+				}
+				return ctx
+			},
 			tokenType: "Bearer",
 			field:     "some-other-field",
 			expected:  "",
 			err:       errMissingField,
 		},
 		{
-			claims:    jwt.MapClaims{},
+			contextFactory: func(t *testing.T) context.Context {
+				token := makeToken(jwt.MapClaims{"some-field": "id-abc-123"}, t)
+				ctx, err := contextWithToken(token, "Bearer")
+				if err != nil {
+					t.Fatalf("Error when building request context: %v", err)
+				}
+				return ctx
+			},
 			tokenType: "token",
+			field:     "some-field",
+			expected:  "",
+			err:       errMissingToken,
+		},
+		{
+			contextFactory: func(t *testing.T) context.Context {
+				return nil
+			},
+			tokenType: "Bearer",
 			field:     "some-field",
 			expected:  "",
 			err:       errMissingToken,
 		},
 	}
 	for _, test := range jwtFieldTests {
-		ctx := context.Background()
-		if len(test.claims) != 0 {
-			token := makeToken(test.claims, t)
-			c, err := contextWithToken(token, test.tokenType)
-			if err != nil {
-				t.Fatalf("Error when building request context: %v", err)
-			}
-			ctx = c
-		}
+		ctx := test.contextFactory(t)
+
 		actual, err := GetJWTFieldWithTokenType(ctx, test.tokenType, test.field, nil)
+
 		if err != test.err {
 			t.Errorf("Invalid error value: %v - expected %v", err, test.err)
 		}

--- a/auth/jwt_test.go
+++ b/auth/jwt_test.go
@@ -109,7 +109,7 @@ func TestGetAccountID(t *testing.T) {
 	}{
 		{
 			claims: jwt.MapClaims{
-				"AccountID": "id-abc-123",
+				MultiTenancyField: "id-abc-123",
 			},
 			expected: "id-abc-123",
 			err:      nil,

--- a/auth/jwt_test.go
+++ b/auth/jwt_test.go
@@ -140,6 +140,13 @@ func TestGetAccountID(t *testing.T) {
 			err:      nil,
 		},
 		{
+			claims: jwt.MapClaims{
+				"AccountID": "id-abc-123",
+			},
+			expected: "id-abc-123",
+			err:      nil,
+		},
+		{
 			claims:   jwt.MapClaims{},
 			expected: "",
 			err:      errMissingField,

--- a/integration/jwt_test.go
+++ b/integration/jwt_test.go
@@ -8,11 +8,12 @@ import (
 )
 
 var (
-	// break apart the token so it isn't one huge line
+	// standardToken is the raw jwt that gets used in test requests. it is signed
+	// with the "testSecret" secret in jwt.go
 	standardToken = fmt.Sprintf("%s%s%s",
 		"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.",
-		"eyJBY2NvdW50SUQiOiJUZXN0QWNjb3VudCJ9.",
-		"Qt7yYMcN2rEYavhgbhVMV762RBmAVUd32mW_VDIAKvM",
+		"eyJhY2NvdW50X2lkIjoiVGVzdEFjY291bnQifQ.",
+		"_Ow6QeeUlW-u1qxAKklmyGOlSeJDaFnwELs-8RPwgBY",
 	)
 )
 


### PR DESCRIPTION
# Change Multi-Tenant Identifier

This pull request changes the multi-tenant ID from `AccountID` to `account_id` for JWT-related purposes.

Also, I fixed a potential issue where `GetJWTFieldWithToken` would panic if it's given a `nil` context.