### PR TITLE
remove liveness check in readiness check

### DIFF
--- a/health/handler.go
+++ b/health/handler.go
@@ -78,7 +78,7 @@ func (ch *checksHandler) healthEndpoint(rw http.ResponseWriter, r *http.Request)
 }
 
 func (ch *checksHandler) readyEndpoint(rw http.ResponseWriter, r *http.Request) {
-	ch.handle(rw, r, ch.readinessChecks, ch.livenessChecks)
+	ch.handle(rw, r, ch.readinessChecks)
 }
 
 func (ch *checksHandler) handle(rw http.ResponseWriter, r *http.Request, checksSets ...map[string]Check) {


### PR DESCRIPTION
Readiness checks in kubernetes performs at an interval post startup. Here, I propose that readiness checks should not include the liveness check along with it as the liveness check should already handle that. This is also something that may be seen as repetitive in the case where readiness probes and liveness probes run at the same time interval. 

I am opening this PR to discuss the different options on this subject. For instance we could give users a choice whether they would like to package the two checks together or have mutually exclusive readiness and liveness checks.

My current stance is reflected in this PR where checks should be separated.