### PR TITLE
Extend toolkit preloading capabilities

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,25 +2,32 @@
 
 
 [[projects]]
+  digest = "1:04aea75705cb453e24bf8c1506a24a5a9036537dbc61ddf71d20900d6c7c3ab9"
   name = "github.com/DATA-DOG/go-sqlmock"
   packages = ["."]
+  pruneopts = "UT"
   revision = "d76b18b42f285b792bf985118980ce9eacea9d10"
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:6e9d2dddd10b5668251398cbd9848b2ea7ebec447d88255abd1437b96c487eb4"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0b96aaa707760d6ab28d9b9d1913ff5993328bae"
 
 [[projects]]
   branch = "master"
+  digest = "1:2560fa383ed6faf04bd505a10c5fee0f98b43753ef07ccb40fce43f0a58f2526"
   name = "github.com/golang/protobuf"
   packages = [
     "jsonpb",
@@ -34,18 +41,22 @@
     "ptypes/duration",
     "ptypes/struct",
     "ptypes/timestamp",
-    "ptypes/wrappers"
+    "ptypes/wrappers",
   ]
+  pruneopts = "UT"
   revision = "93b26e6a70e37abb14f2f88194949312b0592a84"
 
 [[projects]]
+  digest = "1:8f8811f9be822914c3a25c6a071e93beb4c805d7b026cbf298bc577bc1cc945b"
   name = "github.com/google/uuid"
   packages = ["."]
+  pruneopts = "UT"
   revision = "064e2069ce9c359c118179501254f67d7d37ba24"
   version = "0.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:8fc303858c39e0afe678a634f6a051e177fd6f95d10d6aa686325fb6737481d5"
   name = "github.com/grpc-ecosystem/go-grpc-middleware"
   packages = [
     ".",
@@ -53,28 +64,34 @@
     "logging/logrus/ctxlogrus",
     "tags",
     "tags/logrus",
-    "util/metautils"
+    "util/metautils",
   ]
+  pruneopts = "UT"
   revision = "e9c5d9645c437ab1b204cff969a2c0fb16cd4276"
 
 [[projects]]
+  digest = "1:6a06217fc753e65aea71446b777393009ef6797dadc0086c4f75bd16590be04d"
   name = "github.com/grpc-ecosystem/grpc-gateway"
   packages = [
     "runtime",
     "runtime/internal",
-    "utilities"
+    "utilities",
   ]
+  pruneopts = "UT"
   revision = "92583770e3f01b09a0d3e9bdf64321d8bebd48f2"
   version = "v1.4.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:1a1206efd03a54d336dce7bb8719e74f2f8932f661cb9f57d5813a1d99c083d8"
   name = "github.com/grpc-ecosystem/grpc-opentracing"
   packages = ["go/otgrpc"]
+  pruneopts = "UT"
   revision = "8e809c8a86450a29b90dcc9efbf062d0fe6d9746"
 
 [[projects]]
   branch = "master"
+  digest = "1:e1f607322ae1aba3fc6ffaa75994ab56d894f31a39d2e025783382f1cb625829"
   name = "github.com/infobloxopen/go-trees"
   packages = [
     "dltree",
@@ -94,80 +111,100 @@
     "uintX/strtree16",
     "uintX/strtree32",
     "uintX/strtree64",
-    "uintX/strtree8"
+    "uintX/strtree8",
   ]
+  pruneopts = "UT"
   revision = "a1e500cde93cdca91ae6c7366e0cb9f477c63603"
 
 [[projects]]
+  digest = "1:34447b2d58a54b71add4438870fd15f44041961b6fbf129432b5745c11796962"
   name = "github.com/infobloxopen/themis"
   packages = [
     "pdp",
     "pdp-service",
-    "pep"
+    "pep",
   ]
+  pruneopts = "UT"
   revision = "d62bb103665cf16dfcee5083f4557163fb7a68ff"
 
 [[projects]]
+  digest = "1:6895fbe5a10c5aebd1965cac6f6905dcdb21bee01e08912d3ba6a805c2485f6a"
   name = "github.com/jinzhu/gorm"
   packages = [
     ".",
-    "dialects/postgres"
+    "dialects/postgres",
   ]
+  pruneopts = "UT"
   revision = "6ed508ec6a4ecb3531899a69cbc746ccf65a4166"
   version = "v1.9.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:fd97437fbb6b7dce04132cf06775bd258cce305c44add58eb55ca86c6c325160"
   name = "github.com/jinzhu/inflection"
   packages = ["."]
+  pruneopts = "UT"
   revision = "04140366298a54a039076d798123ffa108fff46c"
 
 [[projects]]
   branch = "master"
+  digest = "1:2d370ad7a48d3523291ad53a04b9b1510c182880927f800b46221cc465427800"
   name = "github.com/lib/pq"
   packages = [
     ".",
     "hstore",
-    "oid"
+    "oid",
   ]
+  pruneopts = "UT"
   revision = "90697d60dd844d5ef6ff15135d0203f65d2f53b8"
 
 [[projects]]
+  digest = "1:450b7623b185031f3a456801155c8320209f75d0d4c4e633c6b1e59d44d6e392"
   name = "github.com/opentracing/opentracing-go"
   packages = [
     ".",
     "ext",
-    "log"
+    "log",
   ]
+  pruneopts = "UT"
   revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
   version = "v1.0.2"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:d867dfa6751c8d7a435821ad3b736310c2ed68945d05b50fb9d23aee0540c8cc"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = "UT"
   revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
   version = "v1.0.6"
 
 [[projects]]
+  digest = "1:18752d0b95816a1b777505a97f71c7467a8445b8ffb55631a7bf779f6ba4fa83"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = "UT"
   revision = "c126467f60eb25f8f27e5a981f32a87e3965053f"
 
 [[projects]]
   branch = "master"
+  digest = "1:35dc91eff9861545fea1fd5e723a72202aaeb668f7cda7c415a226ea9e00c35d"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -176,20 +213,24 @@
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "trace"
+    "trace",
   ]
+  pruneopts = "UT"
   revision = "3673e40ba22529d22c3fd7c93e97b0ce50fa7bdd"
 
 [[projects]]
   branch = "master"
+  digest = "1:be95d758fc4d9216e5d41ff5b98b46938fba85ca5bc2ddc45a1b03e2bb10fe7c"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = "UT"
   revision = "e072cadbbdc8dd3d3ffa82b8b4b9304c261d9311"
 
 [[projects]]
+  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -205,23 +246,27 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:9109b88b4156765a10ea3583857f187ffbea70d1068f3ab5dcd33a4c0fa152ce"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/annotations",
     "googleapis/rpc/code",
     "googleapis/rpc/status",
-    "protobuf/field_mask"
+    "protobuf/field_mask",
   ]
+  pruneopts = "UT"
   revision = "02b4e95473316948020af0b7a4f0f22c73929b0e"
 
 [[projects]]
+  digest = "1:2dab32a43451e320e49608ff4542fdfc653c95dcc35d0065ec9c6c3dd540ed74"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -248,14 +293,48 @@
     "stats",
     "status",
     "tap",
-    "transport"
+    "transport",
   ]
+  pruneopts = "UT"
   revision = "168a6198bcb0ef175f7dacec0b8691fc141dc9b8"
   version = "v1.13.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "310dce3383d3c7b0478732c33873a6f051f8d5aa49caadea81ba907e49c86bb5"
+  input-imports = [
+    "github.com/DATA-DOG/go-sqlmock",
+    "github.com/dgrijalva/jwt-go",
+    "github.com/golang/protobuf/jsonpb",
+    "github.com/golang/protobuf/proto",
+    "github.com/golang/protobuf/protoc-gen-go/generator",
+    "github.com/golang/protobuf/ptypes/wrappers",
+    "github.com/google/uuid",
+    "github.com/grpc-ecosystem/go-grpc-middleware/auth",
+    "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus",
+    "github.com/grpc-ecosystem/go-grpc-middleware/tags/logrus",
+    "github.com/grpc-ecosystem/grpc-gateway/runtime",
+    "github.com/grpc-ecosystem/grpc-gateway/utilities",
+    "github.com/infobloxopen/themis/pdp-service",
+    "github.com/infobloxopen/themis/pep",
+    "github.com/jinzhu/gorm",
+    "github.com/jinzhu/gorm/dialects/postgres",
+    "github.com/jinzhu/inflection",
+    "github.com/lib/pq",
+    "github.com/sirupsen/logrus",
+    "github.com/stretchr/testify/assert",
+    "golang.org/x/net/context",
+    "google.golang.org/genproto/googleapis/api/annotations",
+    "google.golang.org/genproto/googleapis/rpc/code",
+    "google.golang.org/genproto/protobuf/field_mask",
+    "google.golang.org/grpc",
+    "google.golang.org/grpc/codes",
+    "google.golang.org/grpc/credentials",
+    "google.golang.org/grpc/grpclog",
+    "google.golang.org/grpc/metadata",
+    "google.golang.org/grpc/peer",
+    "google.golang.org/grpc/status",
+    "google.golang.org/grpc/transport",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/gateway/fields_test.go
+++ b/gateway/fields_test.go
@@ -173,7 +173,7 @@ func ensureRetain(t *testing.T, input, fields, expected string) {
 	}
 
 	flds := query.ParseFieldSelection(fields)
-	doRetainFields(indata, flds.Fields)
+	doRetainFields(indata, flds.GetFields())
 
 	if !reflect.DeepEqual(indata, expdata) {
 		t.Errorf("Filtering input %s on fields %s returned %v while expecting %v", input, fields, indata, expdata)

--- a/gorm/collection_operators.go
+++ b/gorm/collection_operators.go
@@ -114,7 +114,10 @@ func ApplyFieldSelection(ctx context.Context, db *gorm.DB, fs *query.FieldSelect
 		return nil, err
 	}
 	for _, assoc := range toPreload {
-		db = db.Preload(assoc)
+		db, err = preload(db, obj, assoc)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return db, nil
 }

--- a/gorm/fields.go
+++ b/gorm/fields.go
@@ -58,14 +58,11 @@ fields:
 			if err != nil {
 				return nil, err
 			}
-			if subPreload != nil {
-				for i, e := range subPreload {
-					subPreload[i] = sf.Name + "." + e
-				}
-				toPreload = append(toPreload, subPreload...)
-			} else {
-				toPreload = append(toPreload, sf.Name)
+			for i, e := range subPreload {
+				subPreload[i] = sf.Name + "." + e
 			}
+			toPreload = append(toPreload, subPreload...)
+			toPreload = append(toPreload, sf.Name)
 		}
 	}
 	return toPreload, nil
@@ -100,10 +97,7 @@ func handlePreloads(f *query.Field, objType reflect.Type) ([]string, error) {
 		}
 		toPreload = append(toPreload, subPreload...)
 	}
-	if toPreload == nil {
-		return []string{generator.CamelCase(f.GetName())}, nil
-	}
-	return toPreload, nil
+	return append(toPreload, generator.CamelCase(f.GetName())), nil
 }
 
 func getSortedFieldNames(fields map[string]*query.Field) []string {

--- a/gorm/fields.go
+++ b/gorm/fields.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 
 	"github.com/golang/protobuf/protoc-gen-go/generator"
+	"github.com/jinzhu/gorm"
 
 	"github.com/infobloxopen/atlas-app-toolkit/query"
 )
@@ -19,10 +21,10 @@ func FieldSelectionStringToGorm(ctx context.Context, fs string, obj interface{})
 
 // FieldSelectionToGorm receives FieldSelection struct and returns a list of associations to preload.
 func FieldSelectionToGorm(ctx context.Context, fs *query.FieldSelection, obj interface{}) ([]string, error) {
-	if fs == nil {
-		return nil, nil
+	objType := indirectType(reflect.TypeOf(obj))
+	if fs.GetFields() == nil {
+		return preloadEverything(objType, nil)
 	}
-	objType := indirectType(reflect.ValueOf(obj).Type())
 	var toPreload []string
 	fieldNames := getSortedFieldNames(fs.GetFields())
 	for _, fieldName := range fieldNames {
@@ -32,6 +34,39 @@ func FieldSelectionToGorm(ctx context.Context, fs *query.FieldSelection, obj int
 			return nil, err
 		}
 		toPreload = append(toPreload, subPreload...)
+	}
+	return toPreload, nil
+}
+
+func preloadEverything(objType reflect.Type, path []reflect.Type) ([]string, error) {
+	if !isModel(objType) {
+		return nil, fmt.Errorf("%s is not a model", objType)
+	}
+	numField := objType.NumField()
+	var toPreload []string
+fields:
+	for i := 0; i < numField; i++ {
+		sf := objType.Field(i)
+		fType := indirectType(sf.Type)
+		for _, e := range path {
+			if fType == e {
+				continue fields
+			}
+		}
+		if isModel(fType) {
+			subPreload, err := preloadEverything(fType, append(path, objType))
+			if err != nil {
+				return nil, err
+			}
+			if subPreload != nil {
+				for i, e := range subPreload {
+					subPreload[i] = sf.Name + "." + e
+				}
+				toPreload = append(toPreload, subPreload...)
+			} else {
+				toPreload = append(toPreload, sf.Name)
+			}
+		}
 	}
 	return toPreload, nil
 }
@@ -78,4 +113,34 @@ func getSortedFieldNames(fields map[string]*query.Field) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func preload(db *gorm.DB, obj interface{}, assoc string) (*gorm.DB, error) {
+	objType := indirectType(reflect.TypeOf(obj))
+	if !isModel(objType) {
+		return nil, fmt.Errorf("%s is not a model", objType)
+	}
+	assocPath := strings.Split(assoc, ".")
+	pathLength := len(assocPath)
+	for i, part := range assocPath {
+		sf, ok := objType.FieldByName(part)
+		if !ok {
+			return nil, fmt.Errorf("Cannot find %s in %s", part, objType)
+		}
+		objType = indirectType(sf.Type)
+		if !isModel(objType) {
+			return nil, fmt.Errorf("%s is not a model", objType)
+		}
+		if i == pathLength-1 {
+			ok, pos := atlasTag(&sf, "position")
+			if !ok {
+				return db.Preload(assoc), nil
+			} else {
+				return db.Preload(assoc, func(db *gorm.DB) *gorm.DB {
+					return db.Order(gorm.ToDBName(pos))
+				}), nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("Cannot preload empty association")
 }

--- a/gorm/fields_test.go
+++ b/gorm/fields_test.go
@@ -61,7 +61,7 @@ func TestGormFieldSelection(t *testing.T) {
 		},
 		{
 			"sub_model,sub_model.sub_sub_model.sub_sub_property",
-			[]string{"SubModel.SubSubModel"},
+			[]string{"SubModel.SubSubModel", "SubModel"},
 			false,
 		},
 		{
@@ -71,7 +71,7 @@ func TestGormFieldSelection(t *testing.T) {
 		},
 		{
 			"",
-			[]string{"SubModel.SubSubModel", "SubModels.SubSubModel", "CycleModel"},
+			[]string{"SubModel.SubSubModel", "SubModel", "SubModels.SubSubModel", "SubModels", "CycleModel"},
 			false,
 		},
 	}

--- a/gorm/fields_test.go
+++ b/gorm/fields_test.go
@@ -8,9 +8,15 @@ import (
 )
 
 type Model struct {
-	Property  string
-	SubModel  SubModel
-	SubModels []SubModel
+	Property   string
+	SubModel   SubModel
+	SubModels  []SubModel
+	CycleModel *CycleModel
+}
+
+type CycleModel struct {
+	Property string
+	Model    *Model
 }
 
 type SubModel struct {
@@ -61,6 +67,11 @@ func TestGormFieldSelection(t *testing.T) {
 		{
 			"unknown_property",
 			nil,
+			false,
+		},
+		{
+			"",
+			[]string{"SubModel.SubSubModel", "SubModels.SubSubModel", "CycleModel"},
 			false,
 		},
 	}

--- a/gorm/filtering.go
+++ b/gorm/filtering.go
@@ -146,7 +146,7 @@ func StringConditionToGorm(ctx context.Context, c *query.StringCondition, obj in
 }
 
 func processStringCondition(ctx context.Context, c *query.StringCondition, pb proto.Message) (interface{}, error) {
-	objType := indirectType(reflect.ValueOf(pb).Type())
+	objType := indirectType(reflect.TypeOf(pb))
 	pathLength := len(c.FieldPath)
 	for i, part := range c.FieldPath {
 		sf, ok := objType.FieldByName(generator.CamelCase(part))

--- a/gorm/joins.go
+++ b/gorm/joins.go
@@ -12,7 +12,7 @@ import (
 // - source join keys
 // - target join keys
 func JoinInfo(ctx context.Context, obj interface{}, assoc string) (string, []string, []string, error) {
-	objType := indirectType(reflect.ValueOf(obj).Type())
+	objType := indirectType(reflect.TypeOf(obj))
 	sf, ok := objType.FieldByName(assoc)
 	if !ok {
 		return "", nil, nil, fmt.Errorf("Cannot find field %s in %s", assoc, objType)

--- a/gorm/utilities.go
+++ b/gorm/utilities.go
@@ -39,7 +39,7 @@ func HandleFieldPath(ctx context.Context, fieldPath []string, obj interface{}) (
 }
 
 func fieldPathToDBName(fieldPath []string, obj interface{}) (string, error) {
-	objType := indirectType(reflect.ValueOf(obj).Type())
+	objType := indirectType(reflect.TypeOf(obj))
 	pathLength := len(fieldPath)
 	for i, part := range fieldPath {
 		if !isModel(objType) {
@@ -78,7 +78,15 @@ func columnName(sf *reflect.StructField) string {
 }
 
 func gormTag(sf *reflect.StructField, tag string) (bool, string) {
-	gormTags := strings.Split(sf.Tag.Get("gorm"), ";")
+	return extractTag(sf, "gorm", tag)
+}
+
+func atlasTag(sf *reflect.StructField, tag string) (bool, string) {
+	return extractTag(sf, "atlas", tag)
+}
+
+func extractTag(sf *reflect.StructField, tag string, subTag string) (bool, string) {
+	gormTags := strings.Split(sf.Tag.Get(tag), ";")
 	for _, t := range gormTags {
 		var key, value string
 		keyValue := strings.Split(t, ":")
@@ -89,7 +97,7 @@ func gormTag(sf *reflect.StructField, tag string) (bool, string) {
 		case 1:
 			key = keyValue[0]
 		}
-		if strings.ToLower(key) == strings.ToLower(tag) {
+		if strings.ToLower(key) == strings.ToLower(subTag) {
 			return true, value
 		}
 	}

--- a/query/fields.go
+++ b/query/fields.go
@@ -31,7 +31,7 @@ func toParts(input string, delimiter ...string) []string {
 //default, but it is also possible to specify a different delimiter.
 func ParseFieldSelection(input string, delimiter ...string) *FieldSelection {
 	if len(input) == 0 {
-		return &FieldSelection{Fields: nil}
+		return nil
 	}
 
 	fields := strings.Split(input, opCommonDelimiter)

--- a/query/fields_test.go
+++ b/query/fields_test.go
@@ -7,27 +7,27 @@ import (
 )
 
 func TestParse(t *testing.T) {
-	validateParse(t, ParseFieldSelection(""), FieldSelection{Fields: nil})
+	validateParse(t, ParseFieldSelection(""), nil)
 
 	expected := FieldSelection{Fields: FieldSelectionMap{"a": &Field{Name: "a"}}}
-	validateParse(t, ParseFieldSelection("a"), expected)
-	validateParse(t, ParseFieldSelection("a", "?"), expected)
+	validateParse(t, ParseFieldSelection("a"), &expected)
+	validateParse(t, ParseFieldSelection("a", "?"), &expected)
 
 	expected = FieldSelection{Fields: FieldSelectionMap{"a": &Field{Name: "a", Subs: FieldSelectionMap{"b": &Field{Name: "b"}, "c": &Field{Name: "c"}}}}}
-	validateParse(t, ParseFieldSelection("a.b,a.c"), expected)
-	validateParse(t, ParseFieldSelection("a?b,a?c", "?"), expected)
-	validateParse(t, ParseFieldSelection("a-b,a-c", "-", "?"), expected)
+	validateParse(t, ParseFieldSelection("a.b,a.c"), &expected)
+	validateParse(t, ParseFieldSelection("a?b,a?c", "?"), &expected)
+	validateParse(t, ParseFieldSelection("a-b,a-c", "-", "?"), &expected)
 
 	expected = FieldSelection{Fields: FieldSelectionMap{"a": &Field{Name: "a", Subs: FieldSelectionMap{"b": &Field{Name: "b"}, "c": &Field{Name: "c"}}}, "x": &Field{Name: "x"}}}
-	validateParse(t, ParseFieldSelection("a.b,a.c,x"), expected)
+	validateParse(t, ParseFieldSelection("a.b,a.c,x"), &expected)
 
 	expected = FieldSelection{Fields: FieldSelectionMap{"a": &Field{Name: "a", Subs: FieldSelectionMap{"b": &Field{Name: "b", Subs: FieldSelectionMap{"v": &Field{Name: "v"}}}, "c": &Field{Name: "c"}}}, "x": &Field{Name: "x"}}}
-	validateParse(t, ParseFieldSelection("a.b.v,a.c,x"), expected)
-	validateParse(t, ParseFieldSelection("a,a.b,a.b.v,a.c,x"), expected)
+	validateParse(t, ParseFieldSelection("a.b.v,a.c,x"), &expected)
+	validateParse(t, ParseFieldSelection("a,a.b,a.b.v,a.c,x"), &expected)
 }
 
-func validateParse(t *testing.T, result *FieldSelection, expected FieldSelection) {
-	if !reflect.DeepEqual(result, &expected) {
+func validateParse(t *testing.T, result *FieldSelection, expected *FieldSelection) {
+	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("Unexpected parse result %v while expecting %v", result, expected)
 	}
 }
@@ -60,34 +60,34 @@ func TestAdd(t *testing.T) {
 	flds := &FieldSelection{}
 	flds.Add("test")
 	expected := FieldSelection{Fields: FieldSelectionMap{"test": &Field{Name: "test"}}}
-	validateParse(t, flds, expected)
+	validateParse(t, flds, &expected)
 
 	flds = ParseFieldSelection("a.b,x")
 
 	flds.Add("")
 	flds.Add("x")
 	expected = FieldSelection{Fields: FieldSelectionMap{"a": &Field{Name: "a", Subs: FieldSelectionMap{"b": &Field{Name: "b"}}}, "x": &Field{Name: "x"}}}
-	validateParse(t, flds, expected)
+	validateParse(t, flds, &expected)
 
 	flds.Add("a.c")
 	expected = FieldSelection{Fields: FieldSelectionMap{"a": &Field{Name: "a", Subs: FieldSelectionMap{"b": &Field{Name: "b"}, "c": &Field{Name: "c"}}}, "x": &Field{Name: "x"}}}
-	validateParse(t, flds, expected)
+	validateParse(t, flds, &expected)
 
 	flds.Add("a.b.v")
 	expected = FieldSelection{Fields: FieldSelectionMap{"a": &Field{Name: "a", Subs: FieldSelectionMap{"b": &Field{Name: "b", Subs: FieldSelectionMap{"v": &Field{Name: "v"}}}, "c": &Field{Name: "c"}}}, "x": &Field{Name: "x"}}}
-	validateParse(t, flds, expected)
+	validateParse(t, flds, &expected)
 
 	flds.Add("x.y.z")
 	expected = FieldSelection{Fields: FieldSelectionMap{"a": &Field{Name: "a", Subs: FieldSelectionMap{"b": &Field{Name: "b", Subs: FieldSelectionMap{"v": &Field{Name: "v"}}}, "c": &Field{Name: "c"}}}, "x": &Field{Name: "x", Subs: FieldSelectionMap{"y": &Field{Name: "y", Subs: FieldSelectionMap{"z": &Field{Name: "z"}}}}}}}
-	validateParse(t, flds, expected)
+	validateParse(t, flds, &expected)
 
 	flds.Add("t.i")
 	expected = FieldSelection{Fields: FieldSelectionMap{"a": &Field{Name: "a", Subs: FieldSelectionMap{"b": &Field{Name: "b", Subs: FieldSelectionMap{"v": &Field{Name: "v"}}}, "c": &Field{Name: "c"}}}, "x": &Field{Name: "x", Subs: FieldSelectionMap{"y": &Field{Name: "y", Subs: FieldSelectionMap{"z": &Field{Name: "z"}}}}}, "t": &Field{Name: "t", Subs: FieldSelectionMap{"i": &Field{Name: "i"}}}}}
-	validateParse(t, flds, expected)
+	validateParse(t, flds, &expected)
 
 	flds.Add("k")
 	expected = FieldSelection{Fields: FieldSelectionMap{"a": &Field{Name: "a", Subs: FieldSelectionMap{"b": &Field{Name: "b", Subs: FieldSelectionMap{"v": &Field{Name: "v"}}}, "c": &Field{Name: "c"}}}, "x": &Field{Name: "x", Subs: FieldSelectionMap{"y": &Field{Name: "y", Subs: FieldSelectionMap{"z": &Field{Name: "z"}}}}}, "t": &Field{Name: "t", Subs: FieldSelectionMap{"i": &Field{Name: "i"}}}, "k": &Field{Name: "k"}}}
-	validateParse(t, flds, expected)
+	validateParse(t, flds, &expected)
 }
 
 func TestDelete(t *testing.T) {
@@ -110,35 +110,35 @@ func TestDelete(t *testing.T) {
 	}
 
 	expected := FieldSelection{Fields: FieldSelectionMap{"a": &Field{Name: "a", Subs: FieldSelectionMap{"b": &Field{Name: "b", Subs: FieldSelectionMap{"v": &Field{Name: "v"}}}, "c": &Field{Name: "c"}}}, "x": &Field{Name: "x", Subs: FieldSelectionMap{"y": &Field{Name: "y", Subs: FieldSelectionMap{"z": &Field{Name: "z"}}}}}, "t": &Field{Name: "t", Subs: FieldSelectionMap{"i": &Field{Name: "i"}}}}}
-	validateParse(t, flds, expected)
+	validateParse(t, flds, &expected)
 
 	isDel = flds.Delete("t")
 	if isDel == false {
 		t.Error("Unexpected delete result")
 	}
 	expected = FieldSelection{Fields: FieldSelectionMap{"a": &Field{Name: "a", Subs: FieldSelectionMap{"b": &Field{Name: "b", Subs: FieldSelectionMap{"v": &Field{Name: "v"}}}, "c": &Field{Name: "c"}}}, "x": &Field{Name: "x", Subs: FieldSelectionMap{"y": &Field{Name: "y", Subs: FieldSelectionMap{"z": &Field{Name: "z"}}}}}}}
-	validateParse(t, flds, expected)
+	validateParse(t, flds, &expected)
 
 	isDel = flds.Delete("x.y")
 	if isDel == false {
 		t.Error("Unexpected delete result")
 	}
 	expected = FieldSelection{Fields: FieldSelectionMap{"a": &Field{Name: "a", Subs: FieldSelectionMap{"b": &Field{Name: "b", Subs: FieldSelectionMap{"v": &Field{Name: "v"}}}, "c": &Field{Name: "c"}}}, "x": &Field{Name: "x", Subs: FieldSelectionMap{}}}}
-	validateParse(t, flds, expected)
+	validateParse(t, flds, &expected)
 
 	isDel = flds.Delete("a.b.v")
 	if isDel == false {
 		t.Error("Unexpected delete result")
 	}
 	expected = FieldSelection{Fields: FieldSelectionMap{"a": &Field{Name: "a", Subs: FieldSelectionMap{"b": &Field{Name: "b", Subs: FieldSelectionMap{}}, "c": &Field{Name: "c"}}}, "x": &Field{Name: "x", Subs: FieldSelectionMap{}}}}
-	validateParse(t, flds, expected)
+	validateParse(t, flds, &expected)
 
 	isDel = flds.Delete("a")
 	if isDel == false {
 		t.Error("Unexpected delete result")
 	}
 	expected = FieldSelection{Fields: FieldSelectionMap{"x": &Field{Name: "x", Subs: FieldSelectionMap{}}}}
-	validateParse(t, flds, expected)
+	validateParse(t, flds, &expected)
 }
 
 func TestGet(t *testing.T) {


### PR DESCRIPTION
- Return nil FieldSelection if _fields is not present in request

- Extend toolkit preloading capabilities: 
  - Enable ordering for ordered has-many associations via custom preloading
  - Preload everything if FieldSelection is nil

The motivation for this is that GORM `auto_preload` doesn't work with custom preloading, which is required for ordered associations. So we have to avoid autopreloading.
The benefit of this solution is that it supports cyclic associations and doesn't fall into the infinite recursion comparing to autopreloading.