### PR TITLE
Removed Liveness checks from running in readiness checks

### DIFF
--- a/health/handler.go
+++ b/health/handler.go
@@ -78,7 +78,7 @@ func (ch *checksHandler) healthEndpoint(rw http.ResponseWriter, r *http.Request)
 }
 
 func (ch *checksHandler) readyEndpoint(rw http.ResponseWriter, r *http.Request) {
-	ch.handle(rw, r, ch.readinessChecks, ch.livenessChecks)
+	ch.handle(rw, r, ch.readinessChecks)
 }
 
 func (ch *checksHandler) handle(rw http.ResponseWriter, r *http.Request, checksSets ...map[string]Check) {

--- a/health/handler_test.go
+++ b/health/handler_test.go
@@ -73,7 +73,7 @@ func TestNewHandler(t *testing.T) {
 			name:         "Health fail Ready succeed ready",
 			method:       http.MethodGet,
 			path:         "/ready",
-			expectedCode: http.StatusServiceUnavailable,
+			expectedCode: http.StatusOK,
 			failHealth:   true,
 		},
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -90,9 +90,9 @@ func TestWithHealthChecks(t *testing.T) {
 		{"liveness-pass", nil, "healthz", 200},
 		{"liveness-pass", nil, "/healthz", 200},
 		{"liveness-fail", errors.New(""), "/healthz", 503},
-		{"readiness-pass", nil, "ready", 200},
-		{"readiness-pass", nil, "/ready", 200},
-		{"readiness-fail", errors.New(""), "ready", 503},
+		{"readiness-does-not-impact-liveness", nil, "ready", 200},
+		{"readiness-does-not-impact-liveness", nil, "/ready", 200},
+		{"readiness-does-not-impact-liveness", errors.New(""), "ready", 200},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
[PR 100](https://github.com/infobloxopen/atlas-app-toolkit/pull/100)

Took previous PR and updated test cases to reflect changes to readyEndpoint.

Having liveness checks run every time readiness checks eliminates the need for liveness checks at all, as Kubernetes continues to run liveness checks even after an application has been determined to be "ready".