### PR TITLE
fix bug - Filtering/Sorting is not working with different GORM associations.

### DIFF
--- a/gorm/collection_operators.go
+++ b/gorm/collection_operators.go
@@ -94,7 +94,9 @@ func JoinAssociations(ctx context.Context, db *gorm.DB, assoc map[string]struct{
 		for i, k := range sourceKeys {
 			keyPairs = append(keyPairs, k+" = "+targetKeys[i])
 		}
-		db = db.Joins(fmt.Sprintf("LEFT JOIN %s ON %s", tableName, strings.Join(keyPairs, " AND ")))
+		alias := gorm.ToDBName(k)
+		join := fmt.Sprintf("LEFT JOIN %s %s ON %s", tableName, alias, strings.Join(keyPairs, " AND "))
+		db = db.Joins(join)
 	}
 	return db, nil
 }

--- a/gorm/collection_operators_test.go
+++ b/gorm/collection_operators_test.go
@@ -20,8 +20,15 @@ type Person struct {
 	Id        int64
 	Name      string
 	Age       int
+	ParentId  int64
+	Parent    Parent        `gorm:"foreignkey:ParentId;association_foreignkey:Id"`
 	SubPerson SubPerson     `gorm:"foreignkey:PersonId;association_foreignkey:Id"`
 	Items     []OrderedItem `gorm:"foreignkey:PersonId;association_foreignkey:Id" atlas:"position:Position"`
+}
+
+type Parent struct {
+	Id   int64
+	Name string
 }
 
 type SubPerson struct {
@@ -80,7 +87,7 @@ type testResponse struct {
 
 func TestApplyCollectionOperators(t *testing.T) {
 
-	req, err := http.NewRequest("GET", "http://test.com?_fields=id,name,sub_person,items&_filter=age<=25 and sub_person.name=='Mike'&_order_by=age,sub_person.name desc&_limit=2&_offset=1", nil)
+	req, err := http.NewRequest("GET", "http://test.com?_fields=id,name,sub_person,items&_filter=age<=25 and sub_person.name=='Mike'&_order_by=age,sub_person.name,parent.name desc&_limit=2&_offset=1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +104,7 @@ func TestApplyCollectionOperators(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		mock.ExpectQuery(fixedFullRe("SELECT \"people\".* FROM \"people\" LEFT JOIN sub_people ON people.id = sub_people.person_id WHERE (((people.age <= $1) AND (sub_people.name = $2))) ORDER BY people.age,sub_people.name desc LIMIT 2 OFFSET 1")).WithArgs(25.0, "Mike").
+		mock.ExpectQuery(fixedFullRe("SELECT \"people\".* FROM \"people\" LEFT JOIN sub_people sub_person ON people.id = sub_person.person_id LEFT JOIN parents parent ON people.parent_id = parent.id WHERE (((people.age <= $1) AND (sub_person.name = $2))) ORDER BY people.age,sub_person.name,parent.name desc LIMIT 2 OFFSET 1")).WithArgs(25.0, "Mike").
 			WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(111, "Mike"))
 
 		mock.ExpectQuery(fixedFullRe("SELECT * FROM  \"ordered_items\" WHERE (\"person_id\" IN ($1)) ORDER BY \"position\"")).WithArgs(111).

--- a/gorm/filtering_test.go
+++ b/gorm/filtering_test.go
@@ -197,7 +197,7 @@ func TestGormFiltering(t *testing.T) {
 		},
 		{
 			"nested_entity.nested_field1 == 11 and nested_entity.nested_field2 == 22",
-			"((nested_entities.nested_field1 = ?) AND (nested_entities.nested_field2 = ?))",
+			"((nested_entity.nested_field1 = ?) AND (nested_entity.nested_field2 = ?))",
 			[]interface{}{11.0, 22.0},
 			map[string]struct{}{"NestedEntity": {}},
 			nil,

--- a/gorm/joins_test.go
+++ b/gorm/joins_test.go
@@ -33,13 +33,13 @@ func TestJoinInfo(t *testing.T) {
 			"Child",
 			"joins_children",
 			[]string{"joins_models.id"},
-			[]string{"joins_children.model_id"},
+			[]string{"child.model_id"},
 		},
 		{
 			"Parent",
 			"joins_parents",
 			[]string{"joins_models.parent_name"},
-			[]string{"joins_parents.name"},
+			[]string{"parent.name"},
 		},
 	}
 	for _, test := range tests {

--- a/gorm/utilities_test.go
+++ b/gorm/utilities_test.go
@@ -33,7 +33,7 @@ func TestHandleFieldPath(t *testing.T) {
 	}{
 		{[]string{"name"}, "db_humans.name", "", false},
 		{[]string{"age"}, "db_humans.years", "", false},
-		{[]string{"child", "name"}, "children.name", "Child", false},
+		{[]string{"child", "name"}, "child.name", "Child", false},
 		{[]string{}, "", "", true},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Fix bug - filtering/Sorting by nested fields is not working if specified fields belong to the same DB table but different GORM associations.