### PR TITLE
Add per-request context-logger level and pseudo-tracing tags

### DIFF
--- a/gorm/collection_operators_test.go
+++ b/gorm/collection_operators_test.go
@@ -103,8 +103,7 @@ func TestApplyCollectionOperators(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		mock.ExpectQuery(fixedFullRe("SELECT \"people\".* FROM \"people\" LEFT JOIN sub_people sub_person ON people.id = sub_person.person_id LEFT JOIN parents parent ON people.parent_id = parent.id WHERE (((people.age <= $1) AND (sub_person.name = $2))) ORDER BY people.age,sub_person.name,parent.name desc LIMIT 2 OFFSET 1")).WithArgs(25.0, "Mike").
+		mock.ExpectQuery(`^SELECT "people".\* FROM "people" LEFT JOIN [[sub_people sub_person ON people.id = sub_person.person_id LEFT JOIN parents parent ON people.parent_id = parent.id]|[parents parent ON people.parent_id = parent.id LEFT JOIN sub_people sub_person ON people.id = sub_person.person_id]] WHERE (((people.age <= \$1) AND (sub_person.name = \$2))) ORDER BY people.age,sub_person.name,parent.name desc LIMIT 2 OFFSET 1$`).WithArgs(25.0, "Mike").
 			WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(111, "Mike"))
 
 		mock.ExpectQuery(fixedFullRe("SELECT * FROM  \"ordered_items\" WHERE (\"person_id\" IN ($1)) ORDER BY \"position\"")).WithArgs(111).

--- a/logging/README.md
+++ b/logging/README.md
@@ -1,0 +1,13 @@
+## Per Request Logger Settings
+
+The functions here support request scoped log settings.
+Specifically, the log level and a custom log field can be set with the ctxlogrus context logger based on http Header values with the grpc-gateway or via grpc metadata.
+
+The metadata annotator accepts input headers `-H "log-trace-key: <value>"` and `-H "log-level: <level>"`, but with or without it the input headers `-H "grpc-gateway-log-trace-key: <value>"` and `-H "grpc-gateway-log-level: <level>"` will also work.
+
+The `log-trace-key` value is intended to be used for simplifying the process of isolating logs for a single request (so that the request-id doesn't have to be overridden or determined) or a class or requests.
+
+The `LogLevelInterceptor` needs to be placed after the `ctxlogrus.UnaryServerInterceptor`, and accepts its own default logging level, so that the ctxlogrus interceptor (and the interceptors between it and this one) can be allowed to log at a different level than the proceeding ones even without setting it in the request (for example, to always/never log the Info message in the ctxlogrus interceptor, despite having a higher/lower log level).
+Note that the `LogLevelInterceptor` cannot effect whether or not the Info level message in the `ctxlogrus.UnaryServerInterceptor` is printed or not.
+
+The helper function `CopyLoggerWithLevel` can be used to make a deep copy of a logger at a new level, or using `CopyLoggerWithLevel(entry.Logger, level).WithFields(entry.Data)` can copy a logrus.Entry.

--- a/logging/annotator.go
+++ b/logging/annotator.go
@@ -1,0 +1,34 @@
+package logging
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"google.golang.org/grpc/metadata"
+)
+
+// HTTP Headers
+const logLevelHeaderKey = "log-level"
+const logFlagHeaderKey = "log-trace-key"
+
+// Metadata keys used to pass from gateway to service
+const logLevelMetaKey = "log-level"
+const logFlagMetaKey = "log-trace-key"
+
+// Name of field to be logged if included
+const logFlagFieldName = "log-trace-key"
+
+// Annotator is a function that reads the http headers of incoming requests
+// searching for special logging arguments
+func Annotator(ctx context.Context, req *http.Request) metadata.MD {
+	md := make(metadata.MD)
+	if lvl := req.Header.Get(logLevelHeaderKey); lvl != "" {
+		md[runtime.MetadataPrefix+logLevelMetaKey] = []string{lvl}
+	}
+	if flag := req.Header.Get(logFlagHeaderKey); flag != "" {
+		md[runtime.MetadataPrefix+logFlagMetaKey] = []string{flag}
+	}
+
+	return md
+}

--- a/logging/annotator.go
+++ b/logging/annotator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -24,10 +23,10 @@ const logFlagFieldName = "log-trace-key"
 func Annotator(ctx context.Context, req *http.Request) metadata.MD {
 	md := make(metadata.MD)
 	if lvl := req.Header.Get(logLevelHeaderKey); lvl != "" {
-		md[runtime.MetadataPrefix+logLevelMetaKey] = []string{lvl}
+		md[logLevelMetaKey] = []string{lvl}
 	}
 	if flag := req.Header.Get(logFlagHeaderKey); flag != "" {
-		md[runtime.MetadataPrefix+logFlagMetaKey] = []string{flag}
+		md[logFlagMetaKey] = []string{flag}
 	}
 
 	return md

--- a/logging/interceptor.go
+++ b/logging/interceptor.go
@@ -1,0 +1,58 @@
+package logging
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
+	"github.com/infobloxopen/atlas-app-toolkit/gateway"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+// LogLevelInterceptor sets the level of the logger in the context to either
+// the default or the value set in the context via grpc metadata.
+// Also sets the custom log tag if present for pseudo-tracing purposes
+func LogLevelInterceptor(defaultLevel logrus.Level) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (res interface{}, err error) {
+		entry := ctxlogrus.Extract(ctx)
+		lvl := defaultLevel
+		if logLvl, ok := gateway.Header(ctx, logLevelMetaKey); ok {
+			entry.Debugf("Using custom log-level of %q", logLvl)
+			lvl, err = logrus.ParseLevel(logLvl)
+			if err != nil {
+				lvl = defaultLevel
+			}
+		}
+		logFlag, hasFlag := gateway.Header(ctx, logFlagMetaKey)
+		newLogger := CopyLoggerWithLevel(entry.Logger, lvl)
+		fields := entry.Data
+		if hasFlag {
+			fields[logFlagFieldName] = logFlag
+		}
+		newCtx := ctxlogrus.ToContext(ctx, newLogger.WithFields(fields))
+		res, err = handler(newCtx, req)
+
+		// propagate any new or or changed fields from later interceptors back up
+		// the middleware chain
+		resLogger := ctxlogrus.Extract(newCtx)
+		ctxlogrus.AddFields(ctx, resLogger.Data)
+		return
+	}
+}
+
+// CopyLoggerWithLevel makes a copy of the given (logrus) logger at the logger
+// level. If copying an entry, use CopyLoggerWithLevel(entry.Logger, level).WithFields(entry.Data)
+// on the result (changes to these entries' fields will not affect each other).
+func CopyLoggerWithLevel(logger *logrus.Logger, lvl logrus.Level) *logrus.Logger {
+	newLogger := &logrus.Logger{
+		Out:       logger.Out,
+		Hooks:     make(logrus.LevelHooks),
+		Level:     lvl,
+		Formatter: logger.Formatter,
+	}
+	// Copy hooks, so that original Logger hooks are not altered
+	for l, hook := range logger.Hooks {
+		newLogger.Hooks[l] = hook
+	}
+	return newLogger
+}

--- a/logging/interceptor.go
+++ b/logging/interceptor.go
@@ -32,7 +32,7 @@ func LogLevelInterceptor(defaultLevel logrus.Level) grpc.UnaryServerInterceptor 
 		newCtx := ctxlogrus.ToContext(ctx, newLogger.WithFields(fields))
 		res, err = handler(newCtx, req)
 
-		// propagate any new or or changed fields from later interceptors back up
+		// propagate any new or changed fields from later interceptors back up
 		// the middleware chain
 		resLogger := ctxlogrus.Extract(newCtx)
 		ctxlogrus.AddFields(ctx, resLogger.Data)

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"reflect"
@@ -54,7 +55,7 @@ func TestInterceptor(t *testing.T) {
 			return nil, nil
 		}
 	}
-	for _, tc := range []struct {
+	for i, tc := range []struct {
 		origLevel    logrus.Level
 		startFields  logrus.Fields
 		extraFields  logrus.Fields
@@ -103,7 +104,7 @@ func TestInterceptor(t *testing.T) {
 			mdTag:        "special value",
 		},
 	} {
-		t.Run("", func(t *testing.T) {
+		t.Run(fmt.Sprintf("Per-request logging test - %d", i), func(t *testing.T) {
 
 			ctx := context.Background()
 			md := metadata.Pairs(logLevelMetaKey, tc.mdLevel)

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -1,0 +1,143 @@
+package logging
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestAnnotator(t *testing.T) {
+	for input, expect := range map[*map[string]string]metadata.MD{
+		&map[string]string{}:                                                         metadata.MD{},
+		&map[string]string{logLevelHeaderKey: "info"}:                                metadata.MD{logLevelMetaKey: []string{"info"}},
+		&map[string]string{"unused": "info"}:                                         metadata.MD{},
+		&map[string]string{logFlagHeaderKey: "unique-id"}:                            metadata.MD{logFlagMetaKey: []string{"unique-id"}},
+		&map[string]string{logLevelHeaderKey: "info", logFlagHeaderKey: "unique-id"}: metadata.MD{logFlagMetaKey: []string{"unique-id"}, logLevelMetaKey: []string{"info"}},
+	} {
+		postReq := &http.Request{
+			Method: "POST",
+			Header: make(http.Header),
+		}
+		for k, v := range *input {
+			postReq.Header.Add(k, v)
+		}
+		md := Annotator(context.Background(), postReq)
+		if expect == nil && md != nil {
+			t.Error("Did not produce expected nil metadata")
+			continue
+		}
+		if !reflect.DeepEqual(md, expect) {
+			t.Errorf("Did not produce expected metadata %+v, got %+v", expect, md)
+		}
+
+	}
+}
+
+func TestInterceptor(t *testing.T) {
+
+	expectInHandler := func(addFields logrus.Fields, expect *logrus.Entry) func(ctx context.Context, req interface{}) (interface{}, error) {
+		return func(ctx context.Context, req interface{}) (interface{}, error) {
+			logger := ctxlogrus.Extract(ctx)
+			if expect.Logger.Level != logger.Logger.Level {
+				t.Errorf("Expected level %q != Observed level %q", expect.Logger.Level, logger.Logger.Level)
+			}
+			if !reflect.DeepEqual(expect.Data, logger.Data) {
+				t.Errorf("Expected fields %+v != Observed fields %+v", expect.Data, logger.Data)
+			}
+			ctxlogrus.AddFields(ctx, addFields)
+			return nil, nil
+		}
+	}
+	for _, tc := range []struct {
+		origLevel    logrus.Level
+		startFields  logrus.Fields
+		extraFields  logrus.Fields
+		defaultLevel logrus.Level
+		expectLevel  logrus.Level
+		mdLevel      string
+		mdTag        string
+	}{
+		{
+			origLevel:    logrus.DebugLevel,
+			startFields:  logrus.Fields{"source": "testing"},
+			defaultLevel: logrus.InfoLevel,
+			expectLevel:  logrus.WarnLevel,
+			mdLevel:      "warning",
+		},
+		{
+			origLevel:    logrus.DebugLevel,
+			startFields:  logrus.Fields{"source": "testing"},
+			defaultLevel: logrus.InfoLevel,
+			expectLevel:  logrus.InfoLevel,
+			mdLevel:      "invalid",
+		},
+		{
+			origLevel:    logrus.WarnLevel,
+			startFields:  logrus.Fields{"source": "testing"},
+			extraFields:  logrus.Fields{"post-interceptor": "backpropagated?"},
+			defaultLevel: logrus.WarnLevel,
+			expectLevel:  logrus.InfoLevel,
+			mdLevel:      "info",
+		},
+		{
+			origLevel:    logrus.WarnLevel,
+			startFields:  logrus.Fields{"source": "testing"},
+			extraFields:  logrus.Fields{"post-interceptor": "backpropagated?"},
+			defaultLevel: logrus.WarnLevel,
+			expectLevel:  logrus.WarnLevel,
+			mdTag:        "special value",
+		},
+		{
+			origLevel:    logrus.WarnLevel,
+			startFields:  logrus.Fields{"source": "testing"},
+			extraFields:  logrus.Fields{"post-interceptor": "backpropagated?"},
+			defaultLevel: logrus.WarnLevel,
+			expectLevel:  logrus.InfoLevel,
+			mdLevel:      "info",
+			mdTag:        "special value",
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+
+			ctx := context.Background()
+			md := metadata.Pairs(logLevelMetaKey, tc.mdLevel)
+			if tc.mdTag != "" {
+				md = metadata.Join(md, metadata.Pairs(logFlagMetaKey, tc.mdTag))
+			}
+			newCtx := metadata.NewIncomingContext(ctx, md)
+			newCtx = ctxlogrus.ToContext(newCtx, (&logrus.Logger{Level: tc.origLevel, Out: ioutil.Discard, Formatter: &logrus.JSONFormatter{}}).WithFields(tc.startFields))
+			// if the mdTag exists we expect the interceptor to see that field, too
+			if tc.mdTag != "" {
+				tc.startFields[logFlagFieldName] = tc.mdTag
+			}
+			_, err := LogLevelInterceptor(tc.defaultLevel)(newCtx, nil, nil,
+				expectInHandler(tc.extraFields, (&logrus.Logger{Level: tc.expectLevel}).WithFields(tc.startFields)))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			resLogger := ctxlogrus.Extract(newCtx)
+			if resLogger.Logger.Level != tc.origLevel {
+				t.Errorf("Expected level %q != Observed level %q", resLogger.Logger.Level, tc.origLevel)
+			}
+
+			// The context logger should retain fields added before and after the LogLevelInterceptor
+			var expFields = make(logrus.Fields)
+			for k, v := range tc.startFields {
+				expFields[k] = v
+			}
+			for k, v := range tc.extraFields {
+				expFields[k] = v
+			}
+
+			if !reflect.DeepEqual(resLogger.Data, expFields) {
+				t.Errorf("Expected fields %+v != Observed fields %+v", expFields, resLogger.Data)
+			}
+		})
+	}
+}


### PR DESCRIPTION
An annotator and server (unary) interceptor for custom per-request log-level and a `log-trace-key` field for searching logs.

Could probably use additional documentation and some test cases...