### PR TITLE
Add helper function that can prevent errors and reduce log noise

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -29,7 +29,7 @@ message GetMessageRequest {
   string user_id = 2;
 }
 ```
-This enables the following two alternative HTTP JSON to RPC mappings: 
+This enables the following two alternative HTTP JSON to RPC mappings:
 
 | HTTP Verb | REST Endpoint                     | RPC                                                 |
 | ----------|-----------------------------------|---------------------------------------------------- |
@@ -285,6 +285,23 @@ Response with results and service-defined results tag `rpz_hits`
     ...
   ]
 }
+```
+
+## Query String Filtering
+When using the collection operators with the grpc-gateway, extraneous errors may
+be logged during rpcs as the query string is parsed that look like this:
+```
+field not found in *foo.ListFoobarRequest: _order_by
+```
+and the usage of any of the collection operator field names without the leading
+underscore (`order_by`, `filter`,... instead of `_order_by`, `filter`,...) in
+query strings may result in the error `unsupported field type reflect.Value`,
+being returned.
+
+This can be resolved by overwriting the default filter for each rpc with these
+operators using the one defined in response.go.
+```golang
+filter_Foobar_List_0 = gateway.DefaultQueryFilter
 ```
 
 ## Errors

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -299,7 +299,7 @@ query strings may result in the error `unsupported field type reflect.Value`,
 being returned.
 
 This can be resolved by overwriting the default filter for each rpc with these
-operators using the one defined in response.go.
+operators using the one defined in [filter.go](filter.go).
 ```golang
 filter_Foobar_List_0 = gateway.DefaultQueryFilter
 ```

--- a/gateway/response.go
+++ b/gateway/response.go
@@ -4,17 +4,30 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/infobloxopen/atlas-app-toolkit/util"
 	"io"
 	"net/http"
 	"strconv"
+
+	"github.com/infobloxopen/atlas-app-toolkit/util"
 
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/grpc-ecosystem/grpc-gateway/utilities"
 )
+
+// DefaultQueryFilter can be set to override the filter_{service}_{rpc}_{num}
+// field in generated .pb.gw.go files to prevent parse errors in the gateway
+// and potentially reduce log noise due to unrecognized fields
+var DefaultQueryFilter = utilities.NewDoubleArray([][]string{
+	// collection ops and the expected names used for the collection ops objects in requests
+	{"paging"}, {limitQueryKey}, {offsetQueryKey}, {pageTokenQueryKey},
+	{"order_by"}, {sortQueryKey},
+	{"fields"}, {fieldsQueryKey},
+	{"filter"}, {filterQueryKey},
+})
 
 type (
 	// ForwardResponseMessageFunc forwards gRPC response to HTTP client inaccordance with REST API Syntax


### PR DESCRIPTION
Readme update should describe situation well. Internal dev shows that when the leading underscore is not used for collection operators in the URL query strings, things break, and when they are included grpc logging always logs that it doesn't know what to do with it. By including a function like this, that's fixed! (Should create an internal version that includes other query strings that we might commonly use that are specially typed)