### PR TITLE
WIP: Response Errors refactor

### DIFF
--- a/gateway/errors.go
+++ b/gateway/errors.go
@@ -109,17 +109,7 @@ func (h *ProtoErrorHandler) writeError(ctx context.Context, headerWritten bool, 
 		}
 	}
 
-	restErr := make(map[string]interface{})
-	stat := Status(ctx, st)
-	if stat.HTTPStatus != 0 {
-		restErr["status"] = stat.HTTPStatus
-	}
-	if len(stat.Code) > 0 {
-		restErr["code"] = stat.Code
-	}
-	if len(stat.Message) > 0 {
-		restErr["message"] = stat.Message
-	}
+	restErr := Status(ctx, st).ToMap()
 	if len(details) > 0 {
 		restErr["details"] = details
 	}

--- a/gateway/errors_test.go
+++ b/gateway/errors_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestProtoMessageErrorHandlerUnknownCode(t *testing.T) {
 	err := fmt.Errorf("simple text error")
-	v := new(RestError)
+	v := &RestResp{}
 
 	rw := httptest.NewRecorder()
 	ProtoMessageErrorHandler(context.Background(), nil, &runtime.JSONBuiltin{}, rw, nil, err)
@@ -35,22 +35,22 @@ func TestProtoMessageErrorHandlerUnknownCode(t *testing.T) {
 		t.Fatalf("failed to unmarshal response: %s", err)
 	}
 
-	if v.Status.HTTPStatus != http.StatusInternalServerError {
-		t.Errorf("invalid http status: %d", v.Status.HTTPStatus)
+	if v.Error[0]["status"].(float64) != http.StatusInternalServerError {
+		t.Errorf("invalid http status: %d", v.Error[0]["status"])
 	}
 
-	if v.Status.Code != code.Code_UNKNOWN.String() {
-		t.Errorf("invalid code: %s", v.Status.Code)
+	if v.Error[0]["code"] != code.Code_UNKNOWN.String() {
+		t.Errorf("invalid code: %s", v.Error[0]["code"])
 	}
 
-	if v.Status.Message != "simple text error" {
-		t.Errorf("invalid message: %s", v.Status.Message)
+	if v.Error[0]["message"] != "simple text error" {
+		t.Errorf("invalid message: %s", v.Error[0]["message"])
 	}
 }
 
 func TestProtoMessageErrorHandlerUnimplementedCode(t *testing.T) {
 	err := status.Error(codes.Unimplemented, "service not implemented")
-	v := new(RestError)
+	v := new(RestResp)
 
 	rw := httptest.NewRecorder()
 	ProtoMessageErrorHandler(context.Background(), nil, &runtime.JSONBuiltin{}, rw, nil, err)
@@ -66,16 +66,16 @@ func TestProtoMessageErrorHandlerUnimplementedCode(t *testing.T) {
 		t.Fatalf("failed to unmarshal response: %s", err)
 	}
 
-	if v.Status.HTTPStatus != http.StatusNotImplemented {
-		t.Errorf("invalid http status: %d", v.Status.HTTPStatus)
+	if v.Error[0]["status"].(float64) != http.StatusNotImplemented {
+		t.Errorf("invalid http status: %d", v.Error[0]["status"])
 	}
 
-	if v.Status.Code != "NOT_IMPLEMENTED" {
-		t.Errorf("invalid code: %s", v.Status.Code)
+	if v.Error[0]["code"] != "NOT_IMPLEMENTED" {
+		t.Errorf("invalid code: %s", v.Error[0]["code"])
 	}
 
-	if v.Status.Message != "service not implemented" {
-		t.Errorf("invalid message: %s", v.Status.Message)
+	if v.Error[0]["message"] != "service not implemented" {
+		t.Errorf("invalid message: %s", v.Error[0]["message"])
 	}
 }
 
@@ -86,7 +86,7 @@ func TestWriteErrorContainer(t *testing.T) {
 		WithDetail(codes.AlreadyExists, "resource", "x btw already exists.").
 		WithField("x", "Check correct value of 'x'.")
 
-	v := new(RestError)
+	v := new(RestResp)
 
 	rw := httptest.NewRecorder()
 	ProtoMessageErrorHandler(context.Background(), nil, &runtime.JSONBuiltin{}, rw, nil, err)
@@ -95,20 +95,20 @@ func TestWriteErrorContainer(t *testing.T) {
 		t.Fatalf("failed to unmarshal response: %s", err)
 	}
 
-	if v.Status.HTTPStatus != http.StatusBadRequest {
-		t.Errorf("invalid http status: %d", v.Status.HTTPStatus)
+	if v.Error[0]["status"].(float64) != http.StatusBadRequest {
+		t.Errorf("invalid http status: %d", v.Error[0]["status"])
 	}
 
-	if v.Status.Code != "INVALID_ARGUMENT" {
-		t.Errorf("invalid code: %s", v.Status.Code)
+	if v.Error[0]["code"] != "INVALID_ARGUMENT" {
+		t.Errorf("invalid code: %s", v.Error[0]["code"])
 	}
 
-	if v.Status.Message != "Invalid 'x' value." {
-		t.Errorf("invalid message: %s", v.Status.Message)
+	if v.Error[0]["message"] != "Invalid 'x' value." {
+		t.Errorf("invalid message: %s", v.Error[0]["message"])
 	}
 
-	if len(v.Details) != 2 {
-		t.Errorf("invalid details length: %d", len(v.Details))
+	if len(v.Error[0]["details"].([]interface{})) != 2 {
+		t.Errorf("invalid details length: %d", len(v.Error[0]["details"].([]interface{})))
 	}
 
 	details := []interface{}{
@@ -125,19 +125,19 @@ func TestWriteErrorContainer(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(
-		v.Details,
+		v.Error[0]["details"],
 		details,
 	) {
-		t.Errorf("invalid details value: %v", v.Details)
+		t.Errorf("invalid details value: %v", v.Error[0]["details"])
 	}
 
 	fields := map[string][]string{
 		"x": []string{"Check correct value of 'x'."}}
 
-	vMap := v.Fields.(map[string]interface{})
+	vMap := v.Error[0]["fields"].(map[string]interface{})
 
 	if vMap["x"].([]interface{})[0] != fields["x"][0] {
-		t.Errorf("invalid fields value: %v", v.Fields)
+		t.Errorf("invalid fields value: %v", v.Error[0]["fields"])
 	}
 
 }

--- a/gateway/fields.go
+++ b/gateway/fields.go
@@ -22,6 +22,13 @@ func retainFields(ctx context.Context, req *http.Request, dynmap map[string]inte
 	if fieldsStr == "" {
 		return
 	}
+	errs, sucs := errorsAndSuccessesFromContext(ctx)
+	if len(errs) > 0 {
+		dynmap["error"] = errs
+	}
+	if len(sucs) > 0 {
+		dynmap["success"] = sucs
+	}
 
 	fields := query.ParseFieldSelection(fieldsStr)
 	if fields != nil {

--- a/gateway/header.go
+++ b/gateway/header.go
@@ -100,6 +100,9 @@ func handleForwardResponseServerMetadata(matcher runtime.HeaderMatcherFunc, w ht
 
 func handleForwardResponseTrailerHeader(w http.ResponseWriter, md runtime.ServerMetadata) {
 	for k := range md.TrailerMD {
+		if strings.HasPrefix(k, "error-") || strings.HasPrefix(k, "success-") {
+			continue
+		}
 		tKey := textproto.CanonicalMIMEHeaderKey(fmt.Sprintf("%s%s", runtime.MetadataTrailerPrefix, k))
 		w.Header().Add("Trailer", tKey)
 	}

--- a/gateway/response.go
+++ b/gateway/response.go
@@ -111,17 +111,7 @@ func (fw *ResponseForwarder) ForwardMessage(ctx context.Context, mux *runtime.Se
 		dynmap["success"] = []interface{}{rst}
 	} else {
 		if successes, ok := dynmap["success"].([]map[string]interface{}); ok {
-			smap := make(map[string]interface{})
-			if rst.HTTPStatus != 0 {
-				smap["status"] = rst.HTTPStatus
-			}
-			if len(rst.Code) > 0 {
-				smap["code"] = rst.Code
-			}
-			if len(rst.Message) > 0 {
-				smap["message"] = rst.Message
-			}
-			successes = append(successes, smap)
+			successes = append(successes, rst.ToMap())
 			dynmap["success"] = successes
 		}
 	}

--- a/gateway/response_test.go
+++ b/gateway/response_test.go
@@ -53,8 +53,8 @@ func (m *badresult) ProtoMessage()  {}
 func (m *badresult) String() string { return "" }
 
 type response struct {
-	Status *RestStatus `json:"success"`
-	Result []*user     `json:"users"`
+	RestResp
+	Result []*user `json:"users"`
 }
 
 func TestForwardResponseMessage(t *testing.T) {
@@ -82,16 +82,16 @@ func TestForwardResponseMessage(t *testing.T) {
 		t.Fatalf("failed to unmarshal JSON response: %s", err)
 	}
 
-	if v.Status.Code != CodeName(Created) {
-		t.Errorf("invalid status code: %s - expected: %s", v.Status.Code, CodeName(Created))
+	if v.Success[0]["code"] != CodeName(Created) {
+		t.Errorf("invalid status code: %s - expected: %s", v.Success[0]["code"], CodeName(Created))
 	}
 
-	if v.Status.HTTPStatus != http.StatusCreated {
-		t.Errorf("invalid http status code: %d - expected: %d", v.Status.HTTPStatus, http.StatusCreated)
+	if v.Success[0]["status"].(float64) != http.StatusCreated {
+		t.Errorf("invalid http status code: %d - expected: %d", v.Success[0]["status"], http.StatusCreated)
 	}
 
-	if v.Status.Message != "created 1 item" {
-		t.Errorf("invalid status message: %s - expected: %s", v.Status.Message, "created 1 item")
+	if v.Success[0]["message"] != "created 1 item" {
+		t.Errorf("invalid status message: %s - expected: %s", v.Success[0]["message"], "created 1 item")
 	}
 
 	if l := len(v.Result); l != 2 {
@@ -194,14 +194,14 @@ func TestForwardResponseStream(t *testing.T) {
 
 	dec := json.NewDecoder(rw.Body)
 
-	var sv map[string]*RestStatus
+	var sv map[string]*RestResp
 	if err := dec.Decode(&sv); err != nil {
 		t.Fatalf("failed to unmarshal response status: %s", err)
 	}
 	if s, ok := sv["success"]; !ok {
 		t.Fatalf("invalid status response: %v (%v)", s, sv)
 	}
-	rst := sv["success"]
+	rst := sv["success"].Success
 	if rst.Code != CodeName(PartialContent) {
 		t.Errorf("invalid status code: %s - expected: %s", rst.Code, CodeName(PartialContent))
 	}

--- a/gateway/response_test.go
+++ b/gateway/response_test.go
@@ -21,7 +21,7 @@ type user struct {
 }
 
 type result struct {
-	Users []*user `json"users"`
+	Users []*user `json:"users"`
 }
 
 type userWithPtr struct {
@@ -194,14 +194,18 @@ func TestForwardResponseStream(t *testing.T) {
 
 	dec := json.NewDecoder(rw.Body)
 
-	var sv map[string]*RestResp
+	var sv *RestResp
 	if err := dec.Decode(&sv); err != nil {
 		t.Fatalf("failed to unmarshal response status: %s", err)
 	}
-	if s, ok := sv["success"]; !ok {
-		t.Fatalf("invalid status response: %v (%v)", s, sv)
+	if len(sv.Success) < 1 {
+		t.Fatalf("invalid status response has no 'success' field: %v", sv)
 	}
-	rst := sv["success"].Success
+	// expecting only one success message, so the first should be the status
+	rst, ok := FromMap(sv.Success[0])
+	if ok != true {
+		t.Errorf("success response was not the rest status")
+	}
 	if rst.Code != CodeName(PartialContent) {
 		t.Errorf("invalid status code: %s - expected: %s", rst.Code, CodeName(PartialContent))
 	}

--- a/gateway/status.go
+++ b/gateway/status.go
@@ -36,6 +36,48 @@ type RestStatus struct {
 	Message string `json:"message,omitempty"`
 }
 
+func (rs *RestStatus) ToMap() map[string]interface{} {
+	if rs == nil {
+		return nil
+	}
+	m := make(map[string]interface{})
+	if rs.HTTPStatus != 0 {
+		m["status"] = rs.HTTPStatus
+	}
+	if rs.Code != "" {
+		m["code"] = rs.Code
+	}
+	if rs.Message != "" {
+		m["message"] = rs.Message
+	}
+	return m
+}
+func FromMap(m map[string]interface{}) (*RestStatus, bool) {
+	rs := &RestStatus{}
+	for k, v := range m {
+		var ok bool
+		switch k {
+		case "status":
+			var s float64
+			if s, ok = v.(float64); !ok {
+				return nil, false
+			}
+			rs.HTTPStatus = int(s)
+		case "code":
+			if rs.Code, ok = v.(string); !ok {
+				return nil, false
+			}
+		case "message":
+			if rs.Message, ok = v.(string); !ok {
+				return nil, false
+			}
+		default:
+			return nil, false
+		}
+	}
+	return rs, true
+}
+
 // SetStatus sets gRPC status as gRPC metadata
 // Status.Code will be set with metadata key `grpcgateway-status-code` and
 // with value as string name of the code.


### PR DESCRIPTION
Allows for the inclusion of an arbitrary number of `"success"` and `"error"` messages in the response of a call whether or not the entire call fails (e.g. a middleware encountered a non-fatal failure, or several validations failed as separate errors)

The new `gateway.WithSuccess` and `gateway.WithError` functions allow for error and success messages with a `message` field and additional arbitrary fields to be placed in the metadata (using unique numeric tags). These are then processed in the overridden response and error handlers to be inserted into the JSON response alongside the normal message, or the error message, depending on whether the RPC succeeded overall or returned an error.

Tests all succeed right now, but it could use some more code cleanup.