### PR TITLE
Broken DB connection no longer causes panic

### DIFF
--- a/gorm/transaction_test.go
+++ b/gorm/transaction_test.go
@@ -3,6 +3,7 @@ package gorm
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -239,6 +240,15 @@ func TestTransaction_Rollback(t *testing.T) {
 
 	if txn.current != nil {
 		t.Error("failed to reset current gorm instance - txn.current is not nil")
+	}
+
+	fdb, err := gorm.Open("postgres", db)
+	fdb.Close()
+	txn = &Transaction{parent: gdb}
+
+	txn.Begin()
+	if err := txn.Rollback(); !reflect.DeepEqual(err, status.Error(codes.Unavailable, "Database connection not available")) {
+		t.Errorf("Did not receive proper error for broken DB - %s", err)
 	}
 }
 


### PR DESCRIPTION
I somewhat assume that the txn will attempt to rollback if the db breaks, not commit, but it still does a check during commit to prevent a panic there, too, just with less extra details.