### PR TITLE
Enable quote(single/double) escaping in filtering expressions

### DIFF
--- a/query/README.md
+++ b/query/README.md
@@ -66,6 +66,8 @@ Literal values include numbers (integer and floating-point), quoted (both single
 | := | ieq     | Insensitive equal        | city := 'SaNtA ClArA'                                    |
 | in           | Check existence in set   | city in [‘Santa Clara’, ‘New York’] or  price in [1,2,3] |
 
+In order to escape string literal delimiter duplicate it, e.g. for single-quoted string literals: `_filter=field == 'dup single quote '' '`, for double-quoted literals: `_filter=field == "dup double quote "" "`.
+
 Note: if you decide to use toolkit provided `infoblox.api.Filtering` proto type, then you'll not be able to use [vanilla](https://github.com/grpc-ecosystem/grpc-gateway/tree/master/protoc-gen-swagger) swagger schema generation, since this plugin doesn't work with recursive nature of `infoblox.api.Filtering`.
 In this case you can use our [fork](https://github.com/infobloxopen/grpc-gateway/tree/atlas-patch/protoc-gen-swagger) which has a fix for this issue. 
 You can also use [atlas-gentool](https://github.com/infobloxopen/atlas-gentool) which contains both versions of the plugin.

--- a/query/filtering_lexer.go
+++ b/query/filtering_lexer.go
@@ -294,14 +294,20 @@ func (lexer *filteringLexer) string() (Token, error) {
 	term := lexer.curChar
 	s := ""
 	lexer.advance()
-	for lexer.curChar != term {
+	for {
 		if lexer.eof {
 			return nil, &UnexpectedSymbolError{lexer.curChar, lexer.pos}
+		}
+		if lexer.curChar == term {
+			lexer.advance()
+			if lexer.curChar != term {
+				break
+			}
+			// term is escaped
 		}
 		s += string(lexer.curChar)
 		lexer.advance()
 	}
-	lexer.advance()
 	return StringToken{Value: s}, nil
 }
 

--- a/query/filtering_lexer_test.go
+++ b/query/filtering_lexer_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestFilteringLexer(t *testing.T) {
-	lexer := NewFilteringLexer(`()14 13.23 'abc'"bcd" field1 and or  not == eq ne != match ~ nomatch !~ gt > ge >= lt < le <= null := ieq [1,5, 6] ['Hello','World'] in `)
+	lexer := NewFilteringLexer(`()14 13.23 'abc'"bcd" field1 and or  not == eq ne != match ~ nomatch !~ gt > ge >= lt < le <= null := ieq [1,5, 6] ['Hello','World'] in '''""' """''"`)
 	tests := []Token{
 		LparenToken{},
 		RparenToken{},
@@ -41,6 +41,9 @@ func TestFilteringLexer(t *testing.T) {
 		NumberArrayToken{Values: []float64{1, 5, 6}},
 		StringArrayToken{Values: []string{"Hello", "World"}},
 		InToken{},
+		// duplicate terminator to escape
+		StringToken{Value: `'""`},
+		StringToken{Value: `"''`},
 		EOFToken{},
 	}
 


### PR DESCRIPTION
Duplicate single/double quotes to use them in filtering expressions.