### PR TITLE
Enhancements for gateway logging ability, support newer Logrus version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -132,12 +132,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:3f53e9e4dfbb664cd62940c9c4b65a2171c66acd0b7621a1a6b8e78513525a52"
+  digest = "1:87c2e02fb01c27060ccc5ba7c5a407cc91147726f8f40b70cceeedbc52b1f3a8"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ad15b42461921f1fb3529b058c6786c6a45d5162"
-  version = "v1.1.1"
+  revision = "e1e72e9de974bd926e5c56f83753fba2df402ce5"
+  version = "v1.3.0"
 
 [[projects]]
   digest = "1:18752d0b95816a1b777505a97f71c7467a8445b8ffb55631a7bf779f6ba4fa83"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,7 @@
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"
-  version = "1.0.4"
+  version = "1.2.0"
 
 [[constraint]]
   branch = "master"

--- a/errors/context_test.go
+++ b/errors/context_test.go
@@ -233,7 +233,7 @@ func TestContextError(t *testing.T) {
 
 	// Test that new resets isSet flag and turns error into nil.
 
-	New(ctx, codes.InvalidArgument, "target", "<error 1>")
+	New(ctx, codes.InvalidArgument, "target")
 
 	if v := Error(ctx); v != nil {
 		t.Errorf("Unexpected Error result: expected nil, got %v", v)

--- a/logging/README.md
+++ b/logging/README.md
@@ -74,6 +74,26 @@ ctx := metadata.AppendToOutgoingContext(ctx, "log-level", "debug", "log-trace-ke
 response, err := client.SomeRPC(ctx, someRequest)
 ```
 
+## Gateway logging
+
+Certain client interceptors may reject incoming queries (e.g. due to non-conformant json fields).
+This will cause a logging gap compared to queries that fail in the server. To alleviate this, an enhanced gateway logging interceptor is provided.
+The `GatewayLoggingInterceptor` should be in the middleware chain before any that could error out.
+The `GatewayLoggingSentinelInterceptor` should be the very last middleware in the chain.
+
+For example:
+```golang
+...
+	grpc_middleware.ChainUnaryClient(
+		[]grpc.UnaryClientInterceptor{
+			GatewayLoggingInterceptor(logger, EnableDynamicLogLevel, EnableAccountID),
+			...
+			GatewayLoggingSentinelInterceptor(),
+		},
+	)
+...
+```
+
 ## Other functions
 
 The helper function `CopyLoggerWithLevel` can be used to make a deep copy of a logger at a new level, or using `CopyLoggerWithLevel(entry.Logger, level).WithFields(entry.Data)` can copy a logrus.Entry.

--- a/logging/gateway_interceptor.go
+++ b/logging/gateway_interceptor.go
@@ -1,0 +1,166 @@
+package logging
+
+import (
+	"context"
+	"path"
+	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/google/uuid"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
+	"github.com/infobloxopen/atlas-app-toolkit/auth"
+	"github.com/infobloxopen/atlas-app-toolkit/gateway"
+	"github.com/infobloxopen/atlas-app-toolkit/requestid"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+type gwLogCfg struct {
+	dynamicLogLvl bool
+	noRequestID   bool
+	acctIDKeyfunc jwt.Keyfunc
+	withAcctID    bool
+}
+
+// GWLogOption is a type of function that alters a gwLogCfg in the instantiation
+// of a GatewayLoggingInterceptor
+type GWLogOption func(*gwLogCfg)
+
+// NoRequestID disables request-id inclusion (and generation if needed) in gw interceptor logs
+func NoRequestID(o *gwLogCfg) {
+	o.noRequestID = true
+}
+
+// WithDynamicLogLevel enables or disables dynamic log levels like handled in
+// the server interceptor
+func WithDynamicLogLevel(enable bool) GWLogOption {
+	return func(o *gwLogCfg) {
+		o.dynamicLogLvl = enable
+	}
+}
+
+// EnableDynamicLogLevel is a shorthand for WithDynamicLogLevel(true)
+func EnableDynamicLogLevel(o *gwLogCfg) {
+	o.dynamicLogLvl = true
+}
+
+// WithAccountID enables the account_id field in gw interceptor logs, like the
+// server interceptor
+func WithAccountID(keyfunc jwt.Keyfunc) GWLogOption {
+	return func(o *gwLogCfg) {
+		o.withAcctID = true
+		o.acctIDKeyfunc = keyfunc
+	}
+}
+
+// EnableAccountID is a shorthand for WithAccountID(nil)
+func EnableAccountID(o *gwLogCfg) {
+	o.withAcctID = true
+	o.acctIDKeyfunc = nil
+}
+
+type sentinelKeyType int
+
+const sentinelKey = sentinelKeyType(0)
+
+// GatewayLoggingInterceptor handles the functions of the various toolkit interceptors
+// offered for the grpc server, as well as the standard grpc_logrus server interceptor
+// behavior (superset of grpc_logrus client interceptor behavior)
+func GatewayLoggingInterceptor(logger *logrus.Logger, opts ...GWLogOption) grpc.UnaryClientInterceptor {
+	cfg := &gwLogCfg{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return func(ctx context.Context, method string, req interface{}, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) (err error) {
+
+		service := path.Dir(method)[1:]
+		grpcMethod := path.Base(method)
+		fields := logrus.Fields{
+			"grpc.service": service,
+			"grpc.method":  grpcMethod,
+		}
+		startTime := time.Now()
+
+		// Request ID -- defaults to on
+		if !cfg.noRequestID {
+			reqID, exists := requestid.FromContext(ctx)
+			if !exists || reqID == "" {
+				reqID = uuid.New().String()
+			}
+			fields[requestid.DefaultRequestIDKey] = reqID
+			ctx = metadata.AppendToOutgoingContext(ctx, requestid.DefaultRequestIDKey, reqID)
+		}
+
+		// Custom log level
+		lvl := logger.Level
+		if cfg.dynamicLogLvl {
+			if logFlag, ok := gateway.Header(ctx, logFlagMetaKey); ok {
+				fields[logFlagFieldName] = logFlag[0]
+			}
+			if logLvl, ok := gateway.Header(ctx, logLevelMetaKey); ok {
+				lvl, err = logrus.ParseLevel(logLvl)
+				if err != nil {
+					lvl = logger.Level
+				}
+			}
+		}
+
+		// Account ID retrieval -- ever so slightly hacky
+		if cfg.withAcctID {
+			md, _ := metadata.FromOutgoingContext(ctx)
+			if accountID, err := auth.GetAccountID(metadata.NewIncomingContext(ctx, md), cfg.acctIDKeyfunc); err == nil {
+				fields[auth.MultiTenancyField] = accountID
+			} else {
+				logger.Error(err)
+			}
+		}
+
+		// inject logger into context (not done by normal grpc_logrus client interceptor)
+		newLogger := CopyLoggerWithLevel(logger, lvl)
+		newCtx := ctxlogrus.ToContext(ctx, newLogger.WithFields(fields))
+
+		var sentinelValue bool
+		err = invoker(context.WithValue(ctx, sentinelKey, &sentinelValue), method, req, reply, cc, opts...)
+
+		// if the sentinel is set, no middlewares had errors, and it is assumed the
+		// server will log the call in leiu of the gateway doing so
+		if sentinelValue {
+			return
+		}
+
+		// set error message field
+		fields = logrus.Fields{}
+		if err != nil {
+			fields[logrus.ErrorKey] = err
+		}
+
+		// catch any changes made down the middleware chain by re-extracting
+		resLogger := ctxlogrus.Extract(newCtx)
+
+		// duration field
+		durField, durVal := grpc_logrus.DurationToTimeMillisField(time.Now().Sub(startTime))
+		fields[durField] = durVal
+
+		// print log message with all fields
+		resLogger = resLogger.WithFields(fields)
+		resLogger.Info("finished client unary call with code " + grpc.Code(err).String())
+
+		return
+	}
+}
+
+// GatewayLoggingSentinelInterceptor is meant to be the last interceptor in the
+// client interceptor chain, it sets a value left in the context by the
+// GatewayLoggingInterceptor so that it knows whether the call makes it to the
+// server, and thus the server will log the call, and the gateway doesn't need to.
+func GatewayLoggingSentinelInterceptor() grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req interface{}, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) (err error) {
+		succeeded, ok := ctx.Value(sentinelKey).(*bool)
+		if ok {
+			*succeeded = true
+		}
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}

--- a/logging/gateway_interceptor.go
+++ b/logging/gateway_interceptor.go
@@ -28,7 +28,7 @@ type gwLogCfg struct {
 // of a GatewayLoggingInterceptor
 type GWLogOption func(*gwLogCfg)
 
-// NoRequestID disables request-id inclusion (and generation if needed) in gw interceptor logs
+// DisableRequestID disables request-id inclusion (and generation if needed) in gw interceptor logs
 func DisableRequestID(o *gwLogCfg) {
 	o.noRequestID = true
 }

--- a/logging/gateway_interceptor.go
+++ b/logging/gateway_interceptor.go
@@ -29,7 +29,7 @@ type gwLogCfg struct {
 type GWLogOption func(*gwLogCfg)
 
 // NoRequestID disables request-id inclusion (and generation if needed) in gw interceptor logs
-func NoRequestID(o *gwLogCfg) {
+func DisableRequestID(o *gwLogCfg) {
 	o.noRequestID = true
 }
 
@@ -131,7 +131,7 @@ func GatewayLoggingInterceptor(logger *logrus.Logger, opts ...GWLogOption) grpc.
 		err = invoker(context.WithValue(ctx, sentinelKey, &sentinelValue), method, req, reply, cc, opts...)
 
 		// if the sentinel is set, no middlewares had errors, and it is assumed the
-		// server will log the call in leiu of the gateway doing so
+		// server will log the call instead of the gateway doing so
 		if sentinelValue {
 			return
 		}

--- a/logging/gateway_interceptor.go
+++ b/logging/gateway_interceptor.go
@@ -136,18 +136,18 @@ func GatewayLoggingInterceptor(logger *logrus.Logger, opts ...GWLogOption) grpc.
 			return
 		}
 
-		// set error message field
-		fields = logrus.Fields{}
-		if err != nil {
-			fields[logrus.ErrorKey] = err
-		}
-
 		// catch any changes made down the middleware chain by re-extracting
 		resLogger := ctxlogrus.Extract(newCtx)
 
-		// duration field
 		durField, durVal := grpc_logrus.DurationToTimeMillisField(time.Now().Sub(startTime))
-		fields[durField] = durVal
+		fields = logrus.Fields{
+			durField:    durVal,
+			"grpc.code": grpc.Code(err).String(),
+		}
+		// set error message field
+		if err != nil {
+			fields[logrus.ErrorKey] = err
+		}
 
 		// print log message with all fields
 		resLogger = resLogger.WithFields(fields)

--- a/logging/gateway_interceptor.go
+++ b/logging/gateway_interceptor.go
@@ -77,11 +77,17 @@ func GatewayLoggingInterceptor(logger *logrus.Logger, opts ...GWLogOption) grpc.
 
 		service := path.Dir(method)[1:]
 		grpcMethod := path.Base(method)
-		fields := logrus.Fields{
-			"grpc.service": service,
-			"grpc.method":  grpcMethod,
-		}
 		startTime := time.Now()
+		fields := logrus.Fields{
+			grpc_logrus.SystemField: "grpc",
+			grpc_logrus.KindField:   "gateway",
+			"grpc.service":          service,
+			"grpc.method":           grpcMethod,
+			"grpc.start_time":       startTime.Format(time.RFC3339),
+		}
+		if d, ok := ctx.Deadline(); ok {
+			fields["grpc.request.deadline"] = d.Format(time.RFC3339)
+		}
 
 		// Request ID -- defaults to on
 		if !cfg.noRequestID {

--- a/logging/interceptor.go
+++ b/logging/interceptor.go
@@ -44,10 +44,12 @@ func LogLevelInterceptor(defaultLevel logrus.Level) grpc.UnaryServerInterceptor 
 // on the result (changes to these entries' fields will not affect each other).
 func CopyLoggerWithLevel(logger *logrus.Logger, lvl logrus.Level) *logrus.Logger {
 	newLogger := &logrus.Logger{
-		Out:       logger.Out,
-		Hooks:     make(logrus.LevelHooks),
-		Level:     lvl,
-		Formatter: logger.Formatter,
+		Out:          logger.Out,
+		Hooks:        make(logrus.LevelHooks),
+		Level:        lvl,
+		Formatter:    logger.Formatter,
+		ReportCaller: logger.ReportCaller,
+		ExitFunc:     logger.ExitFunc,
 	}
 	// Copy hooks, so that original Logger hooks are not altered
 	for l, hook := range logger.Hooks {


### PR DESCRIPTION
Should probably also include some accompanying tests.

The big deal is a combined grpc_logrus/log-level/request-id/auth middleware for the gateway instead of the server. Also includes a sentinel middleware for the other side to let the primary middleware know if the request made it through or failed in the middleware chain (if it made it through, it assumes the server will log the request so it doesn't have to).

Also fixes a test case in a random file. And ups the logrus version and includes supporting change in the `CopyLoggerWithLevel` function.