### PR TITLE
Discard gRPC metadata from gateway response

### DIFF
--- a/gateway/header.go
+++ b/gateway/header.go
@@ -80,12 +80,9 @@ func HeaderN(ctx context.Context, key string, n int) (val []string, found bool) 
 	}
 }
 
-// PrefixOutgoingHeaderMatcher prefixes outgoing gRPC metadata with
-// runtime.MetadataHeaderPrefix ("Grpc-Metadata-").
-// It behaves like the default gRPC-Gateway outgoing header matcher
-// (if none is provided as an option).
+// PrefixOutgoingHeaderMatcher discards all grpc header metadata.
 func PrefixOutgoingHeaderMatcher(key string) (string, bool) {
-	return fmt.Sprintf("%s%s", runtime.MetadataHeaderPrefix, key), true
+	return "", false
 }
 
 func handleForwardResponseServerMetadata(matcher runtime.HeaderMatcherFunc, w http.ResponseWriter, md runtime.ServerMetadata) {

--- a/gateway/header_test.go
+++ b/gateway/header_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"google.golang.org/grpc/metadata"
-
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 )
 
 func TestHeader(t *testing.T) {
@@ -60,7 +58,7 @@ func TestHeaderN(t *testing.T) {
 func TestPrefixOutgoingHeaderMatcher(t *testing.T) {
 	key := "Content-Type"
 	v, ok := PrefixOutgoingHeaderMatcher(key)
-	if !ok || v != runtime.MetadataHeaderPrefix+key {
-		t.Errorf("header %s is not matched: %s, %v", key, v, ok)
+	if ok {
+		t.Errorf("header %s hasn't been discarded: %s", key, v)
 	}
 }

--- a/gateway/response_test.go
+++ b/gateway/response_test.go
@@ -66,7 +66,7 @@ func TestForwardResponseMessage(t *testing.T) {
 	enc.Encode(map[string]interface{}{"code": CodeName(Created), "status": 201})
 	md := runtime.ServerMetadata{
 		HeaderMD: metadata.Pairs(
-			"status-code", CodeName(Created),
+			"grpcgateway-status-code", CodeName(Created),
 		),
 		TrailerMD: metadata.Pairs(
 			"success-1", "message:deleted 1 item",
@@ -85,6 +85,11 @@ func TestForwardResponseMessage(t *testing.T) {
 
 	if ct := rw.Header().Get("Content-Type"); ct != "application/json" {
 		t.Errorf("invalid content-type: %s - expected: %s", ct, "application/json")
+	}
+
+	mdSt := "Grpc-Metadata-Grpcgateway-Status-Code"
+	if h := rw.Header().Get(mdSt); h != "" {
+		t.Errorf("got %s: %s", mdSt, h)
 	}
 
 	v := &response{}


### PR DESCRIPTION
This information is useless for REST clients.