### PR TITLE
make PostrgesDB public to remove restrictions

### DIFF
--- a/integration/postgres.go
+++ b/integration/postgres.go
@@ -19,7 +19,7 @@ func (e testDatabaseError) Error() string {
 	return fmt.Sprintf("testing database error: %s", e.message)
 }
 
-type testPostgresDB struct {
+type PostgresDB struct {
 	host                string
 	port                int
 	dbName              string
@@ -33,12 +33,12 @@ type testPostgresDB struct {
 
 // NewTestPostgresDB returns a test postgres database that
 // the functional options that have been provided by the caller
-func NewTestPostgresDB(opts ...option) (testPostgresDB, error) {
+func NewTestPostgresDB(opts ...option) (PostgresDB, error) {
 	port, err := GetOpenPortInRange(35000, portRangeMax)
 	if err != nil {
-		return testPostgresDB{}, err
+		return PostgresDB{}, err
 	}
-	db := testPostgresDB{
+	db := PostgresDB{
 		port:       port,
 		dbName:     "test-postgres-db",
 		dbUser:     "postgres",
@@ -55,7 +55,7 @@ func NewTestPostgresDB(opts ...option) (testPostgresDB, error) {
 // Reset drops all the tables in a test database and regenerates them by
 // running migrations. If a migration function has not been specified, then the
 // tables are dropped but not regenerated
-func (db testPostgresDB) Reset() error {
+func (db PostgresDB) Reset() error {
 	dbSQL, err := sql.Open("postgres", db.GetDSN())
 	if err != nil {
 		return err
@@ -84,7 +84,7 @@ func (db testPostgresDB) Reset() error {
 
 // RunAsDockerContainer spins-up a Postgres database server as a Docker
 // container. The test Postgres database will run inside this Docker container.
-func (db testPostgresDB) RunAsDockerContainer() (func() error, error) {
+func (db PostgresDB) RunAsDockerContainer() (func() error, error) {
 	cleanup, err := RunContainer(
 		// define the postgres image version
 		fmt.Sprintf("postgres:%s", db.dbVersion),
@@ -103,14 +103,14 @@ func (db testPostgresDB) RunAsDockerContainer() (func() error, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := db.checkConnection(); err != nil {
+	if err := db.CheckConnection(); err != nil {
 		cleanup()
 		return nil, err
 	}
 	return cleanup, nil
 }
 
-func (db testPostgresDB) checkConnection() error {
+func (db PostgresDB) CheckConnection() error {
 	ctx, cancel := context.WithTimeout(context.Background(), db.timeout)
 	defer cancel()
 	errStream := make(chan error)
@@ -135,50 +135,50 @@ func (db testPostgresDB) checkConnection() error {
 }
 
 // GetDSN returns the database connection string for the test Postgres database
-func (db testPostgresDB) GetDSN() string {
+func (db PostgresDB) GetDSN() string {
 	return fmt.Sprintf(
 		"host=localhost port=%d user=%s password=%s sslmode=disable dbname=%s",
 		db.port, db.dbUser, db.dbPassword, db.dbName,
 	)
 }
 
-type option func(*testPostgresDB)
+type option func(*PostgresDB)
 
 // WithName is used to specify the name of the test Postgres database. By default
 // the database name is "test-postgres-db"
-func WithName(name string) func(*testPostgresDB) {
-	return func(db *testPostgresDB) {
+func WithName(name string) func(*PostgresDB) {
+	return func(db *PostgresDB) {
 		db.dbName = name
 	}
 }
 
 // WithPort is used to specify the port of the test Postgres database. By
 // default, the test database will find the first open port in the 35000+ range
-func WithPort(port int) func(*testPostgresDB) {
-	return func(db *testPostgresDB) {
+func WithPort(port int) func(*PostgresDB) {
+	return func(db *PostgresDB) {
 		db.port = port
 	}
 }
 
 // WithUser is used to specify the name of the Postgres user that owns the
 // test database
-func WithUser(user string) func(*testPostgresDB) {
-	return func(db *testPostgresDB) {
+func WithUser(user string) func(*PostgresDB) {
+	return func(db *PostgresDB) {
 		db.dbUser = user
 	}
 }
 
 // WithPassword is used to specify the password of the test Postgres database
-func WithPassword(password string) func(*testPostgresDB) {
-	return func(db *testPostgresDB) {
+func WithPassword(password string) func(*PostgresDB) {
+	return func(db *PostgresDB) {
 		db.dbPassword = password
 	}
 }
 
 // WithVersion is used to specify the version of the test Postgres database. By
 // default the version is "latest"
-func WithVersion(version string) func(*testPostgresDB) {
-	return func(db *testPostgresDB) {
+func WithVersion(version string) func(*PostgresDB) {
+	return func(db *PostgresDB) {
 		db.dbVersion = version
 	}
 }
@@ -186,8 +186,8 @@ func WithVersion(version string) func(*testPostgresDB) {
 // WithMigrateFunction is used to rebuild the test Postgres database on a
 // per-test basis. Whenever the database is reset with the Reset() function, the
 // migrateUp function will rebuild the tables.
-func WithMigrateUpFunction(migrateUpFunction func(*sql.DB) error) func(*testPostgresDB) {
-	return func(db *testPostgresDB) {
+func WithMigrateUpFunction(migrateUpFunction func(*sql.DB) error) func(*PostgresDB) {
+	return func(db *PostgresDB) {
 		db.migrateUpFunction = migrateUpFunction
 	}
 }
@@ -195,15 +195,15 @@ func WithMigrateUpFunction(migrateUpFunction func(*sql.DB) error) func(*testPost
 // WithMigrateFunction is used to tear down the test Postgres according to a
 // specific set of migrations. It runs on a per-test basis whenever the Reset()
 // function is called.
-func WithMigrateDownFunction(migrateDownFunction func(*sql.DB) error) func(*testPostgresDB) {
-	return func(db *testPostgresDB) {
+func WithMigrateDownFunction(migrateDownFunction func(*sql.DB) error) func(*PostgresDB) {
+	return func(db *PostgresDB) {
 		db.migrateDownFunction = migrateDownFunction
 	}
 }
 
 // WithTimeout is used to specify a connection timeout to the database
-func WithTimeout(timeout time.Duration) func(*testPostgresDB) {
-	return func(db *testPostgresDB) {
+func WithTimeout(timeout time.Duration) func(*PostgresDB) {
+	return func(db *PostgresDB) {
 		db.timeout = timeout
 	}
 }

--- a/integration/postgres_test.go
+++ b/integration/postgres_test.go
@@ -12,7 +12,7 @@ import (
 
 // buildDB creates a new test Postgres database and halts the test if anything
 // fails during this process
-func buildDB(t *testing.T, opts ...option) testPostgresDB {
+func buildDB(t *testing.T, opts ...option) PostgresDB {
 	db, err := NewTestPostgresDB(opts...)
 	if err != nil {
 		t.Fatalf("unable to create test postgres database")
@@ -71,7 +71,7 @@ func TestCheckConnection(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	db.host = "some-fake-hostname"
-	if err := db.checkConnection(); err == nil {
+	if err := db.CheckConnection(); err == nil {
 		t.Errorf("expected to get non-nil error")
 	}
 	db.host = "localhost"


### PR DESCRIPTION
That PR have made PostgresDB type public available, that add possibility to declare PostgresDB as global variable and use for integration tests