### PR TITLE
Err fields

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -169,11 +169,49 @@ func (s *myService) MyMethod(req *MyRequest) (*MyResponse, error) {
 ### Response Format
 Unless another format is specified in the request `Accept` header that the service supports, services render resources in responses in JSON format by default.
 
-Services must embed their response in a Success JSON structure.
+By default for a successful RPC call only the proto response is rendered as JSON, however for a failed call a special format is used, and by calling special methods the response can include additional metadata.
 
-The Success JSON structure provides a uniform structure for expressing normal responses using a structure similar to the Error JSON structure used to render errors. The structure provides an enumerated set of codes and associated HTTP statuses (see Errors below) along with a message.
+The `WithSuccess(ctx context.Context, msg MessageWithFields)` function allows you to add a `success` block to the returned JSON.
+By default this block only contains a message field, however arbitrary key-value pairs can also be included.
+This is included at top level, alongside the assumed `result` or `results` field.
 
-The Success JSON structure has the following format. The results tag is optional and appears when the response contains one or more resources.
+Ex.
+```json
+{
+  "success": {
+    "foo": "bar",
+    "baz": 1,
+    "message": <message-text>
+  },
+  "results": <service-response>
+}
+```
+
+The `WithError(ctx context.Context, err error)` function allows you to add an extra `error` to the `errors` list in the returned JSON.
+The `NewWithFields(message string, kvpairs ...interface{})` function can be used to create this error, which then includes additional fields in the error, otherwise only the error message will be included.
+This is included at top level, alongside the assumed `result` or `results` field if the call succeeded despite the error, or alone otherwise.
+
+Ex.
+```json
+{
+  "errors": [
+    {
+      "foo": "bar",
+      "baz": 1,
+      "message": <message-text>
+    }
+  ],
+  "results": <service-response>
+}
+```
+
+To return an error with fields and fail the RPC, return an error from `NewResponseError(ctx context.Context, msg string, kvpairs ...interface{})` or `NewResponseErrorWithCode(ctx context.Context, c codes.Code, msg string, kvpairs ...interface{})` to also set the return code.
+
+The function `IncludeStatusDetails(withDetails bool)` allows you to include the `success` block with fields `code` and `status` automatically for all responses,
+and the first of the `errors` in failed responses will also include the fields.
+Note that this choice affects all responses that pass through `gateway.ForwardResponseMessage`.
+
+Ex:
 ```json
 {
   "success": {
@@ -185,11 +223,7 @@ The Success JSON structure has the following format. The results tag is optional
 }
 ```
 
-The `results` content follows the [Google model](https://cloud.google.com/apis/design/standard_methods): an object is returned for Get, Create and Update operations and list of objects for List operation.
-
-To allow compatibility with existing systems, the results tag name can be changed to a service-defined tag. In this way the success data becomes just a tag added to an existing structure.
-
-#### Example Success Responses
+#### Example Success Responses With IncludeStatusDetails(true)
 
 Response with no results
 ```json
@@ -304,33 +338,6 @@ operators using the one defined in [filter.go](filter.go).
 filter_Foobar_List_0 = gateway.DefaultQueryFilter
 ```
 
-## Errors
-
-### Format
-Method error responses are rendered in the Error JSON format. The Error JSON format is similar to the Success JSON format.
-
-The Error JSON structure has the following format. The details tag is optional and appears when the service provides more details about the error.
-```json
-{
-  "error": {
-    "status": <http-status-code>,
-    "code": <enumerated-error-code>,
-    "message": <message-text>
-  },
-  "details": [
-    {
-      "message": <message-text>,
-      "code": <enumerated-error-code>,
-      "target": <resource-name>,
-    },
-    ...
-  ],
-  "fields": {
-      "field1": [<message-1>, <message-2>, ...],
-      "field2": ...,
-  }
-}
-```
 
 ### Translating gRPC Errors to HTTP
 
@@ -370,6 +377,9 @@ You can find sample in example folder. See [code](example/cmd/gateway/main.go)
 
 The idiomatic way to send an error from you gRPC service is to simple return
 it from you gRPC handler either as `status.Errorf()` or `errors.New()`.
+If additional fields are required, then use the
+`NewResponseError(ctx context.Context, msg string, kvpairs ...interface{})` or
+`NewResponseErrorWithCode(ctx context.Context, c codes.Code, msg string, kvpairs ...interface{})` functions instead.
 
 ```go
 import (
@@ -379,5 +389,9 @@ import (
 
 func (s *myServiceImpl) MyMethod(req *MyRequest) (*MyResponse, error) {
     return nil, status.Errorf(codes.Unimplemented, "method is not implemented: %v", req)
+}
+
+func (s *myServiceImpl) MyMethod2(ctx context.Context, req *MyRequest) (*MyResponse, error) {
+    return nil, NewResponseErrorWithCode(ctx, codes.Internal, "something broke on our end", "retry_in", 30)
 }
 ```

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -229,9 +229,9 @@ Response with no results
 ```json
 {
   "success": {
-    "status": 201,
+    "status": "CREATED",
     "message": "Account provisioned",
-    "code": "CREATED"
+    "code": 201
   }
 }
 ```
@@ -240,9 +240,9 @@ Response with results
 ```json
 {
   "success": {
-    "status": 200,
+    "status": "OK",
     "message": "Found 2 items",
-    "code": "OK"
+    "code": 200
   },
   "results": [
     {
@@ -269,9 +269,9 @@ Response for get by id operation
 ```json
 {
   "success": {
-    "status": 200,
+    "status": "OK",
     "message": "object found",
-    "code": "OK"
+    "code": 200
   },
   "results": {
       "account_id": 4,
@@ -286,9 +286,9 @@ Response with results and service-defined results tag `rpz_hits`
 ```json
 {
   "success": {
-    "status": 200,
+    "status": "OK",
     "message": "Read 360 items",
-    "code": "OK"
+    "code": 200
   },
   "rpz_hits": [
     {

--- a/gateway/response.go
+++ b/gateway/response.go
@@ -40,6 +40,8 @@ var (
 	setStatusDetails = false
 )
 
+// IncludeStatusDetails enables/disables output of status & code fields in all http json
+// translated in the gateway with this package's ForwardResponseMessage
 func IncludeStatusDetails(withDetails bool) {
 	setStatusDetails = withDetails
 }

--- a/gateway/response.go
+++ b/gateway/response.go
@@ -90,7 +90,7 @@ func (fw *ResponseForwarder) ForwardMessage(ctx context.Context, mux *runtime.Se
 	}
 
 	retainFields(ctx, req, dynmap)
-	errs, suc := errorsAndSuccessFromContext(ctx)
+	errs, suc, _ := errorsAndSuccessFromContext(ctx)
 	if _, ok := dynmap["error"]; len(errs) > 0 && !ok {
 		dynmap["error"] = errs
 	}

--- a/gateway/response_test.go
+++ b/gateway/response_test.go
@@ -98,11 +98,11 @@ func TestForwardResponseMessage(t *testing.T) {
 	}
 
 	if v.Success["status"] != CodeName(Created) {
-		t.Errorf("invalid status code: %s - expected: %s", v.Success["code"], CodeName(Created))
+		t.Errorf("invalid status string: %s - expected: %s", v.Success["status"], CodeName(Created))
 	}
 
 	if v.Success["code"].(float64) != http.StatusCreated {
-		t.Errorf("invalid http status code: %d - expected: %d", v.Success["status"], http.StatusCreated)
+		t.Errorf("invalid http status code: %d - expected: %d", v.Success["code"], http.StatusCreated)
 	}
 
 	if v.Success["message"] != "created 1 item" {
@@ -158,11 +158,11 @@ func TestForwardResponseMessageWithDetailsIncluded(t *testing.T) {
 	}
 
 	if v.Success["status"] != CodeName(Created) {
-		t.Errorf("invalid status code: %s - expected: %s", v.Success["code"], CodeName(Created))
+		t.Errorf("invalid status string: %s - expected: %s", v.Success["status"], CodeName(Created))
 	}
 
 	if v.Success["code"].(float64) != http.StatusCreated {
-		t.Errorf("invalid http status code: %d - expected: %d", v.Success["status"], http.StatusCreated)
+		t.Errorf("invalid http status code: %d - expected: %d", v.Success["code"], http.StatusCreated)
 	}
 
 	if v.Success["message"] != "created 1 item" {
@@ -224,7 +224,7 @@ func TestForwardResponseMessageWithErrorsAndDetailsIncluded(t *testing.T) {
 	}
 
 	if v.Success["status"] != CodeName(Created) {
-		t.Errorf("invalid status code: %s - expected: %s", v.Success["status"], CodeName(Created))
+		t.Errorf("invalid status string: %s - expected: %s", v.Success["status"], CodeName(Created))
 	}
 
 	if v.Success["code"].(float64) != http.StatusCreated {

--- a/gateway/response_test.go
+++ b/gateway/response_test.go
@@ -63,7 +63,7 @@ type response struct {
 func TestForwardResponseMessage(t *testing.T) {
 	b := &bytes.Buffer{}
 	enc := json.NewEncoder(b)
-	enc.Encode(map[string]interface{}{"code": CodeName(Created), "status": 201})
+	enc.Encode(map[string]interface{}{"code": 201, "status": CodeName(Created)})
 	md := runtime.ServerMetadata{
 		HeaderMD: metadata.Pairs(
 			"grpcgateway-status-code", CodeName(Created),
@@ -97,16 +97,146 @@ func TestForwardResponseMessage(t *testing.T) {
 		t.Fatalf("failed to unmarshal JSON response: %s", err)
 	}
 
-	if v.Success["code"] != CodeName(Created) {
+	if v.Success["status"] != CodeName(Created) {
 		t.Errorf("invalid status code: %s - expected: %s", v.Success["code"], CodeName(Created))
 	}
 
-	if v.Success["status"].(float64) != http.StatusCreated {
+	if v.Success["code"].(float64) != http.StatusCreated {
 		t.Errorf("invalid http status code: %d - expected: %d", v.Success["status"], http.StatusCreated)
 	}
 
 	if v.Success["message"] != "created 1 item" {
 		t.Errorf("invalid status message: %s - expected: %s", v.Success["message"], "created 1 item")
+	}
+
+	if l := len(v.Result); l != 2 {
+		t.Fatalf("invalid number of items in response result: %d - expected: %d", l, 2)
+	}
+
+	poe, hemingway := v.Result[0], v.Result[1]
+	if poe.Name != "Poe" || poe.Age != 209 {
+		t.Errorf("invalid result item: %+v - expected: %+v", poe, &user{"Poe", 209})
+	}
+
+	if hemingway.Name != "Hemingway" || hemingway.Age != 119 {
+		t.Errorf("invalid result item: %+v - expected: %+v", hemingway, &user{"Hemingway", 119})
+	}
+}
+
+func TestForwardResponseMessageWithDetailsIncluded(t *testing.T) {
+	IncludeStatusDetails(true)
+	defer IncludeStatusDetails(false)
+	md := runtime.ServerMetadata{
+		HeaderMD: metadata.Pairs(
+			"grpcgateway-status-code", CodeName(Created),
+		),
+		TrailerMD: metadata.Pairs(
+			"success-1", "message:deleted 1 item",
+			"success-5", "message:created 1 item",
+		),
+	}
+	ctx := runtime.NewServerMetadataContext(context.Background(), md)
+	rw := httptest.NewRecorder()
+	ForwardResponseMessage(ctx, nil, &runtime.JSONBuiltin{}, rw, nil, &result{Users: []*user{{"Poe", 209}, {"Hemingway", 119}}})
+
+	if rw.Code != http.StatusCreated {
+		t.Errorf("invalid http status code: %d - expected: %d", rw.Code, http.StatusCreated)
+	}
+
+	if ct := rw.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("invalid content-type: %s - expected: %s", ct, "application/json")
+	}
+
+	mdSt := "Grpc-Metadata-Grpcgateway-Status-Code"
+	if h := rw.Header().Get(mdSt); h != "" {
+		t.Errorf("got %s: %s", mdSt, h)
+	}
+
+	v := &response{}
+	if err := json.Unmarshal(rw.Body.Bytes(), v); err != nil {
+		t.Fatalf("failed to unmarshal JSON response: %s", err)
+	}
+
+	if v.Success["status"] != CodeName(Created) {
+		t.Errorf("invalid status code: %s - expected: %s", v.Success["code"], CodeName(Created))
+	}
+
+	if v.Success["code"].(float64) != http.StatusCreated {
+		t.Errorf("invalid http status code: %d - expected: %d", v.Success["status"], http.StatusCreated)
+	}
+
+	if v.Success["message"] != "created 1 item" {
+		t.Errorf("invalid status message: %s - expected: %s", v.Success["message"], "created 1 item")
+	}
+
+	if l := len(v.Result); l != 2 {
+		t.Fatalf("invalid number of items in response result: %d - expected: %d", l, 2)
+	}
+
+	poe, hemingway := v.Result[0], v.Result[1]
+	if poe.Name != "Poe" || poe.Age != 209 {
+		t.Errorf("invalid result item: %+v - expected: %+v", poe, &user{"Poe", 209})
+	}
+
+	if hemingway.Name != "Hemingway" || hemingway.Age != 119 {
+		t.Errorf("invalid result item: %+v - expected: %+v", hemingway, &user{"Hemingway", 119})
+	}
+}
+
+func TestForwardResponseMessageWithErrorsAndDetailsIncluded(t *testing.T) {
+	IncludeStatusDetails(true)
+	defer IncludeStatusDetails(false)
+	b := &bytes.Buffer{}
+	enc := json.NewEncoder(b)
+	enc.Encode(map[string]interface{}{"bar": 2})
+	md := runtime.ServerMetadata{
+		HeaderMD: metadata.Pairs(
+			"grpcgateway-status-code", CodeName(Created),
+		),
+		TrailerMD: metadata.Pairs(
+			"error-1", "message:err message",
+			"error-1", fmt.Sprintf("fields:%q", string(b.Bytes()))),
+	}
+	ctx := runtime.NewServerMetadataContext(context.Background(), md)
+	rw := httptest.NewRecorder()
+	ForwardResponseMessage(ctx, nil, &runtime.JSONBuiltin{}, rw, nil, &result{Users: []*user{{"Poe", 209}, {"Hemingway", 119}}})
+
+	if rw.Code != http.StatusCreated {
+		t.Errorf("invalid http status code: %d - expected: %d", rw.Code, http.StatusCreated)
+	}
+
+	if ct := rw.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("invalid content-type: %s - expected: %s", ct, "application/json")
+	}
+
+	mdSt := "Grpc-Metadata-Grpcgateway-Status-Code"
+	if h := rw.Header().Get(mdSt); h != "" {
+		t.Errorf("got %s: %s", mdSt, h)
+	}
+
+	v := &response{}
+	if err := json.Unmarshal(rw.Body.Bytes(), v); err != nil {
+		t.Fatalf("failed to unmarshal JSON response: %s", err)
+	}
+
+	if len(v.Error) != 1 {
+		t.Errorf("did not contain expected error in response")
+	}
+
+	if v.Success["status"] != CodeName(Created) {
+		t.Errorf("invalid status code: %s - expected: %s", v.Success["status"], CodeName(Created))
+	}
+
+	if v.Success["code"].(float64) != http.StatusCreated {
+		t.Errorf("invalid http status code: %d - expected: %d", v.Success["code"], http.StatusCreated)
+	}
+
+	if v.Error[0]["bar"].(float64) != 2 {
+		t.Errorf("unexpected err field: %d - expected: %d", v.Error[0]["bar"], 2)
+	}
+
+	if v.Error[0]["message"] != "err message" {
+		t.Errorf("invalid status message: %s - expected: %s", v.Error[0]["message"], "err message")
 	}
 
 	if l := len(v.Result); l != 2 {

--- a/gateway/status.go
+++ b/gateway/status.go
@@ -75,7 +75,7 @@ func HTTPStatus(ctx context.Context, st *status.Status) (int, string) {
 	if st != nil {
 		httpStatus := HTTPStatusFromCode(st.Code())
 
-		return httpStatus, st.Code().String()
+		return httpStatus, CodeName(st.Code())
 	}
 	code := CodeName(codes.OK)
 	if sc, ok := Header(ctx, "status-code"); ok {

--- a/gateway/status.go
+++ b/gateway/status.go
@@ -77,13 +77,13 @@ func HTTPStatus(ctx context.Context, st *status.Status) (int, string) {
 
 		return httpStatus, CodeName(st.Code())
 	}
-	code := CodeName(codes.OK)
+	statusName := CodeName(codes.OK)
 	if sc, ok := Header(ctx, "status-code"); ok {
-		code = sc
+		statusName = sc
 	}
-	httpStatus := HTTPStatusFromCode(Code(code))
+	httpCode := HTTPStatusFromCode(Code(statusName))
 
-	return httpStatus, code
+	return httpCode, statusName
 }
 
 // CodeName returns stringname of gRPC code, function handles as standard

--- a/gateway/status.go
+++ b/gateway/status.go
@@ -66,17 +66,16 @@ func SetRunning(ctx context.Context, message, resource string) error {
 }
 
 // Status returns REST representation of gRPC status.
-// If status.Status is not nil it will be converted in accrodance with REST
+// If status.Status is not nil it will be converted in accordance with REST
 // API Syntax otherwise context will be used to extract
-// `grpcgatewau-status-code` and `grpcgateway-status-message` from
-// gRPC metadata.
-// If `grpcgatewau-status-code` is not set it is assumed that it is OK.
-func HTTPStatus(ctx context.Context, st *status.Status) int {
+// `grpcgateway-status-code` from gRPC metadata.
+// If `grpcgateway-status-code` is not set it is assumed that it is OK.
+func HTTPStatus(ctx context.Context, st *status.Status) (int, string) {
 
 	if st != nil {
 		httpStatus := HTTPStatusFromCode(st.Code())
 
-		return httpStatus
+		return httpStatus, st.Code().String()
 	}
 	code := CodeName(codes.OK)
 	if sc, ok := Header(ctx, "status-code"); ok {
@@ -84,7 +83,7 @@ func HTTPStatus(ctx context.Context, st *status.Status) int {
 	}
 	httpStatus := HTTPStatusFromCode(Code(code))
 
-	return httpStatus
+	return httpStatus, code
 }
 
 // CodeName returns stringname of gRPC code, function handles as standard

--- a/gateway/status_test.go
+++ b/gateway/status_test.go
@@ -15,10 +15,13 @@ import (
 
 func TestStatus(t *testing.T) {
 	// test REST status from gRPC one
-	stat := HTTPStatus(context.Background(), status.New(codes.OK, "success message"))
+	stat, statName := HTTPStatus(context.Background(), status.New(codes.OK, "success message"))
 
 	if stat != http.StatusOK {
 		t.Errorf("invalid http status code %d - expected: %d", stat, http.StatusOK)
+	}
+	if statName != codes.OK.String() {
+		t.Errorf("invalid http status codename %q - expected: %q", statName, codes.OK.String())
 	}
 
 	// test REST status from incoming context
@@ -26,10 +29,13 @@ func TestStatus(t *testing.T) {
 		runtime.MetadataPrefix+"status-code", CodeName(Created),
 	)
 	ctx := metadata.NewIncomingContext(context.Background(), md)
-	stat = HTTPStatus(ctx, nil)
+	stat, statName = HTTPStatus(ctx, nil)
 
 	if stat != http.StatusCreated {
 		t.Errorf("invalid http status code %d - expected: %d", stat, http.StatusCreated)
+	}
+	if statName != CodeName(Created) {
+		t.Errorf("invalid http status codename %q - expected: %q", statName, codes.OK.String())
 	}
 }
 


### PR DESCRIPTION
Currently, it isn't possible to return an error with any additional fields (using WithError can have extra fields, but is in addition to any error returned by the RPC). This change adds a function that can be called when returning an error to also specify extra details, as well as a function which toggles automatic inclusion of the `status` and `code` fields in response statuses.