### PR TITLE
Add request-id annotator

### DIFF
--- a/requestid/metadata_annotator.go
+++ b/requestid/metadata_annotator.go
@@ -1,0 +1,20 @@
+package requestid
+
+import (
+	"context"
+	"net/http"
+
+	"google.golang.org/grpc/metadata"
+)
+
+func NewRequestIDAnnotator() func(context.Context, *http.Request) metadata.MD {
+	return func(ctx context.Context, req *http.Request) metadata.MD {
+		if req.Header.Get(DefaultRequestIDKey) != "" {
+			md := make(metadata.MD)
+			md.Set(DefaultRequestIDKey, req.Header.Get(DefaultRequestIDKey))
+			return md
+		} else {
+			return nil
+		}
+	}
+}

--- a/requestid/metadata_annotator_test.go
+++ b/requestid/metadata_annotator_test.go
@@ -1,0 +1,28 @@
+package requestid
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"google.golang.org/grpc/metadata"
+)
+
+func generateRequestID(requestId string) map[string]string {
+	mdmap := map[string]string{
+		DefaultRequestIDKey: requestId,
+	}
+	return mdmap
+}
+
+func TestRequestIDMetadataAnnotator(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://127.0.0.1:8080/myrequest/", nil)
+	req.Header.Add("Request-Id", "my-request")
+	f := NewRequestIDAnnotator()
+	expMetadata := metadata.New(generateRequestID("my-request"))
+	resultMD := f(context.Background(), req)
+	if !reflect.DeepEqual(expMetadata, resultMD) {
+		t.Errorf("Result: %v Expected: %v", resultMD, expMetadata)
+	}
+}


### PR DESCRIPTION
Currently if `Request-ID` is passed during the REST call in headers is not reflected in the logs. The request grpc middleware looks for `Request-ID` in `ctx`. But it can not find it even though its passed explicitly. This helps in debugging.

This PR  creates an metadata annotator that appends the request-Id in `ctx` in grpc gateway.

Demo:
 Before:
```
 curl  -X GET -H "Request-Id: test-request" "http://localhost:8080/xyz/v1/abc"
 respose:
  {"error":[{"message":"Internal error occurred. For more details see log for request 65680fc0-e59e-49d0-93f6-dcb9c13771db"}]
```
 Now:
```
 curl  -X GET -H "Request-Id: test-request" "http://localhost:8080/xyz/v1/abc"
 respose:
  {"error":[{"message":"Internal error occurred. For more details see log for request test-request "}]
```