### PR TITLE
CustomIncomingHeaderMatcher func is used to add custom headers

### DIFF
--- a/gateway/header.go
+++ b/gateway/header.go
@@ -114,9 +114,10 @@ func handleForwardResponseTrailer(w http.ResponseWriter, md runtime.ServerMetada
 	}
 }
 
-// CustomIncomingHeaderMatcher func is used to add custom headers to be matched
-// from incoming http requests, If this returns true the header will be added to grpc context
-func CustomIncomingHeaderMatcher(headerNames ...string) func(string) (string, bool) {
+// ExtendedDefaultHeaderMatcher func is used to add custom headers to be matched
+// from incoming http requests, If this returns true the header will be added to grpc context.
+// This function also passes through all the headers that runtime.DefaultHeaderMatcher handles.
+func ExtendedDefaultHeaderMatcher(headerNames ...string) func(string) (string, bool) {
 	customHeaders := map[string]bool{}
 	for _, name := range headerNames {
 		customHeaders[strings.ToLower(name)] = true

--- a/gateway/header.go
+++ b/gateway/header.go
@@ -113,3 +113,19 @@ func handleForwardResponseTrailer(w http.ResponseWriter, md runtime.ServerMetada
 		}
 	}
 }
+
+// CustomIncomingHeaderMatcher func is used to add custom headers to be matched
+// from incoming http requests, If this returns true the header will be added to grpc context
+func CustomIncomingHeaderMatcher(headerNames ...string) func(string) (string, bool) {
+	customHeaders := map[string]bool{}
+	for _, name := range headerNames {
+		customHeaders[strings.ToLower(name)] = true
+	}
+	return func(headerName string) (string, bool) {
+		if key, ok := runtime.DefaultHeaderMatcher(headerName); ok {
+			return key, ok
+		}
+		_, ok := customHeaders[strings.ToLower(headerName)]
+		return headerName, ok
+	}
+}

--- a/gateway/header_test.go
+++ b/gateway/header_test.go
@@ -62,3 +62,52 @@ func TestPrefixOutgoingHeaderMatcher(t *testing.T) {
 		t.Errorf("header %s hasn't been discarded: %s", key, v)
 	}
 }
+
+func TestCustomHeaderMatcher(t *testing.T) {
+	var customMatcherTests = []struct {
+		name          string
+		customHeaders []string
+		in            string
+		isValid       bool
+	}{
+		{
+			name:          "Customer headers | success",
+			customHeaders: []string{"Request-ID", "ophid"},
+			in:            "Request-Id",
+			isValid:       true,
+		},
+		{
+			name:          "Customer headers| failure",
+			customHeaders: []string{"Request-ID", "ophid"},
+			in:            "RequestId",
+			isValid:       false,
+		},
+		{
+			name:          "Default headers | success",
+			customHeaders: []string{"Request-ID", "ophid"},
+			in:            "grpc-metadata-Request-Id",
+			isValid:       true,
+		},
+		{
+			name:          "Default headers | without custom headers",
+			customHeaders: []string{},
+			in:            "grpc-metadata-Request-Id",
+			isValid:       true,
+		},
+		{
+			name:          "custom headers in | without custom headers | failure",
+			customHeaders: []string{},
+			in:            "Request-Id",
+			isValid:       false,
+		},
+	}
+	for _, tt := range customMatcherTests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := CustomIncomingHeaderMatcher(tt.customHeaders...)
+			_, ok := f(tt.in)
+			if ok != tt.isValid {
+				t.Errorf("got %v, want %v", ok, tt.isValid)
+			}
+		})
+	}
+}

--- a/gateway/header_test.go
+++ b/gateway/header_test.go
@@ -63,7 +63,7 @@ func TestPrefixOutgoingHeaderMatcher(t *testing.T) {
 	}
 }
 
-func TestCustomHeaderMatcher(t *testing.T) {
+func TestExtendedDefaultHeaderMatcher(t *testing.T) {
 	var customMatcherTests = []struct {
 		name          string
 		customHeaders []string
@@ -71,13 +71,13 @@ func TestCustomHeaderMatcher(t *testing.T) {
 		isValid       bool
 	}{
 		{
-			name:          "Customer headers | success",
+			name:          "Custom headers | success",
 			customHeaders: []string{"Request-ID", "ophid"},
 			in:            "Request-Id",
 			isValid:       true,
 		},
 		{
-			name:          "Customer headers| failure",
+			name:          "Custom headers | failure",
 			customHeaders: []string{"Request-ID", "ophid"},
 			in:            "RequestId",
 			isValid:       false,
@@ -103,7 +103,7 @@ func TestCustomHeaderMatcher(t *testing.T) {
 	}
 	for _, tt := range customMatcherTests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := CustomIncomingHeaderMatcher(tt.customHeaders...)
+			f := ExtendedDefaultHeaderMatcher(tt.customHeaders...)
 			_, ok := f(tt.in)
 			if ok != tt.isValid {
 				t.Errorf("got %v, want %v", ok, tt.isValid)


### PR DESCRIPTION
to be matched from incoming http requests, If this returns true
the header will be added to grpc context.

E.g. Apps can add headers like `Request-ID` to be accepted from REST
requests.