### PR TITLE
first pass of resource id

### DIFF
--- a/bloxid/doc.go
+++ b/bloxid/doc.go
@@ -1,0 +1,12 @@
+// Bloxid implements typed guids for identifying resource
+// objects globally in the system. Resources are not specific
+// to services/applications but must contain an entity type.
+//
+// Typed guids have the advantage of being globally unique,
+// easily readable, and strongly typed for authorization and
+// logging. The trailing characters provide sufficient entropy
+// to make each resource universally unique.
+//
+// Bloxid package provides methods for generating and parsing
+// versioned typed guids.
+package bloxid

--- a/bloxid/interface.go
+++ b/bloxid/interface.go
@@ -1,0 +1,17 @@
+package bloxid
+
+// ID implements the interface for parsing a resource identifier
+type ID interface {
+	// String returns the complete resource ID
+	String() string
+	// ShortID returns a shortened ID that will be locally unique
+	ShortID() string
+	// Version returns a serialized representation of the ID version
+	// ie. `V0`
+	Version() string // V0
+	// Type returns entity type ie. `host`
+	Type() string
+	// Region is optional and returns the cloud region that
+	// the resource is found in ie. `us-east-1`
+	Region() string
+}

--- a/bloxid/rand.go
+++ b/bloxid/rand.go
@@ -1,0 +1,22 @@
+package bloxid
+
+import (
+	"crypto/rand"
+)
+
+const (
+	DefaultEntropySize = 40
+)
+
+func randDefault() []byte {
+	return randBytes(DefaultEntropySize)
+}
+
+func randBytes(size int) []byte {
+	b := make([]byte, size/2)
+	_, err := rand.Read(b)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/bloxid/rand_test.go
+++ b/bloxid/rand_test.go
@@ -1,0 +1,11 @@
+package bloxid
+
+import "testing"
+
+func TestRandBytes(t *testing.T) {
+	size := 10
+	bs := randBytes(10)
+	if size/2 != len(bs) {
+		t.Errorf("got: %d wanted: %d", len(bs), size)
+	}
+}

--- a/bloxid/v0.go
+++ b/bloxid/v0.go
@@ -1,0 +1,193 @@
+package bloxid
+
+import (
+	"encoding/base32"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	VersionUnknown Version = iota
+	Version0       Version = iota
+)
+
+type Version uint8
+
+func (v Version) String() string {
+	name, ok := version_name[v]
+	if !ok {
+		return version_name[VersionUnknown]
+	}
+	return name
+}
+
+var version_name = map[Version]string{
+	VersionUnknown: "unknown",
+	Version0:       "blox0",
+}
+
+var name_version = map[string]Version{
+	"unknown": VersionUnknown,
+	"blox0":   Version0,
+}
+
+var (
+	ErrInvalidVersion     error = errors.New("invalid bloxid version")
+	ErrInvalidEntityType  error = errors.New("entity type must be non-empty")
+	ErrInvalidUniqueIDLen error = errors.New("unique ID did not meet minimum length requirements")
+
+	ErrIDEmpty error = errors.New("empty bloxid")
+	ErrV0Parts error = errors.New("invalid number of parts found")
+)
+
+// NewV0 parse a string into a typed guid, return an error
+// if the string fails validation.
+func NewV0(bloxid string) (*V0, error) {
+	if len(bloxid) == 0 {
+		return nil, ErrIDEmpty
+	}
+
+	return parseV0(bloxid)
+}
+
+const V0Delimiter = "."
+
+func parseV0(bloxid string) (*V0, error) {
+	if err := validateV0(bloxid); err != nil {
+		return nil, err
+	}
+
+	parts := strings.Split(bloxid, V0Delimiter)
+	v0 := &V0{
+		version:    name_version[parts[0]],
+		entityType: parts[1],
+		region:     parts[2],
+		encoded:    parts[3],
+	}
+
+	decodedTall := strings.ToUpper(parts[3])
+	decoded, err := base32.StdEncoding.DecodeString(decodedTall)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode id: %s", err)
+	}
+	v0.decoded = fmt.Sprintf("%x", decoded)
+
+	return v0, nil
+}
+
+func validateV0(bloxid string) error {
+	parts := strings.Split(bloxid, V0Delimiter)
+	if len(parts) != 4 {
+		return ErrV0Parts
+	}
+
+	if ver := parts[0]; ver != Version0.String() {
+		return ErrInvalidVersion
+	}
+
+	if entityType := parts[1]; len(entityType) == 0 {
+		return ErrInvalidEntityType
+	}
+
+	if len(parts[3]) < DefaultEntropySize/2 {
+		return ErrInvalidUniqueIDLen
+	}
+
+	return nil
+}
+
+var _ ID = &V0{}
+
+// V0 represents a typed guid
+type V0 struct {
+	version      Version
+	region       string
+	customSuffix string
+	decoded      string
+	encoded      string
+	entityType   string
+	shortID      string
+}
+
+// Serialize the typed guid as a string
+func (v *V0) String() string {
+	s := []string{
+		v.Version(),
+		v.entityType,
+		v.region,
+		v.encoded,
+	}
+	return strings.Join(s, ".")
+}
+
+// Region implements ID.Region
+func (v *V0) Region() string {
+	if v == nil {
+		return ""
+	}
+	return v.region
+}
+
+// ShortID implements ID.ShortID
+func (v *V0) ShortID() string {
+	if v == nil {
+		return ""
+	}
+	return v.shortID
+}
+
+// Type implements ID.Type
+func (v *V0) Type() string {
+	if v == nil {
+		return ""
+	}
+	return v.entityType
+}
+
+// Version of the string
+func (v *V0) Version() string {
+	if v == nil {
+		return VersionUnknown.String()
+	}
+	return v.version.String()
+}
+
+// V0Options required options to create a typed guid
+type V0Options struct {
+	Region     string
+	EntityType string
+	shortid    string
+}
+
+type GenerateV0Opts func(o *V0Options)
+
+func WithShortID(shortid string) func(o *V0Options) {
+	return func(o *V0Options) {
+		o.shortid = shortid
+	}
+}
+
+func GenerateV0(opts *V0Options, fnOpts ...GenerateV0Opts) (*V0, error) {
+
+	for _, fn := range fnOpts {
+		fn(opts)
+	}
+
+	encoded, decoded := uniqueID(opts)
+
+	return &V0{
+		version:    Version0,
+		region:     opts.Region,
+		decoded:    decoded,
+		encoded:    encoded,
+		entityType: opts.EntityType,
+	}, nil
+}
+
+func uniqueID(opts *V0Options) (encoded string, decoded string) {
+	entropy := randDefault()
+	decoded = fmt.Sprintf("%x", entropy)
+	encoded = strings.ToLower(base32.StdEncoding.EncodeToString(entropy))
+	return
+}

--- a/bloxid/v0_test.go
+++ b/bloxid/v0_test.go
@@ -1,0 +1,97 @@
+package bloxid
+
+import (
+	"testing"
+)
+
+func TestNewV0(t *testing.T) {
+	var testmap = []struct {
+		input      string
+		output     string
+		entityType string
+		decoded    string
+		err        error
+	}{
+		{
+			"",
+			"",
+			"",
+			"",
+			ErrIDEmpty,
+		},
+		{
+			"blox0.pkg..zdud52youveke5sovyoc66cjxw3l55jc",
+			"blox0.pkg..zdud52youveke5sovyoc66cjxw3l55jc",
+			"pkg",
+			"c8e83eeb0ea548a2764eae1c2f7849bdb6bef522",
+			nil,
+		},
+		{
+			input: "bloxv0.pkg..asdfasdfasdfasdfasdfasdf",
+			err:   ErrInvalidVersion,
+		},
+		{
+			input: "blox0...adsf",
+			err:   ErrInvalidEntityType,
+		},
+		{
+			input: "blox0.a..a",
+			err:   ErrInvalidUniqueIDLen,
+		},
+	}
+
+	for _, tm := range testmap {
+		v0, err := NewV0(tm.input)
+		if err != tm.err {
+			t.Log(tm.input)
+			t.Errorf("got: %s wanted: %s", err, tm.err)
+		}
+		if err != nil {
+			continue
+		}
+		if v0.String() != tm.output {
+			t.Errorf("got: %s wanted: %s", v0.String(), tm.output)
+		}
+
+		if v0.decoded != tm.decoded {
+			t.Errorf("got: %q wanted: %q", v0.decoded, tm.decoded)
+		}
+
+		if v0.entityType != tm.entityType {
+			t.Errorf("got: %q wanted: %q", v0.entityType, tm.entityType)
+		}
+	}
+}
+
+func TestGenerateV0(t *testing.T) {
+	var testmap = []struct {
+		shortid    string
+		entityType string
+		output     string
+		err        error
+	}{
+		{
+			shortid:    "",
+			entityType: "pkg",
+		},
+	}
+
+	for _, tm := range testmap {
+		v0, err := GenerateV0(&V0Options{
+			EntityType: tm.entityType,
+		}, WithShortID(tm.shortid))
+		if err != tm.err {
+			t.Errorf("got: %s wanted: %s", err, tm.err)
+		}
+		if err != nil {
+			continue
+		}
+
+		if v0 == nil {
+			t.Errorf("unexpected nil version")
+			continue
+		}
+		t.Log(v0)
+		t.Logf("%#v\n", v0)
+	}
+}


### PR DESCRIPTION
```
Application services require a mechanism to encode the identity of a particular resource across applications. The resource identifiers consist of typed guid containing a version, resource type, region and unique id.

In database tables, the resource identifier should be stored in its original form. The typed guid will be used in inter-service contracts. It may be beneficial to store the typed guid in other formats but should be done in addition to the full representation. This identifier is globally unique and sufficient for use as a Primary Key. 

What a typed guid looks like:

    blox1.<RESOURCE TYPE>.[REGION].<UNIQUE ID>

blox1.account..3kj4bhjf3h4fiuokn3idgfdhgfo2kjknlk2ns34iu6iub6bs
blox1.host.us-east1.asygyiu32y2u3y4b5buboiufuy2fo34uy2cytdtfdg

```