### PR TITLE
Expose HandleRequestID

### DIFF
--- a/requestid/interceptor.go
+++ b/requestid/interceptor.go
@@ -3,7 +3,7 @@ package requestid
 import (
 	"context"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"google.golang.org/grpc"
 )
 
@@ -17,7 +17,7 @@ import (
 func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (res interface{}, err error) {
 
-		reqID := handleRequestID(ctx)
+		reqID := HandleRequestID(ctx)
 		// add request id to logger
 		addRequestIDToLogger(ctx, reqID)
 
@@ -35,7 +35,7 @@ func StreamServerInterceptor() grpc.StreamServerInterceptor {
 
 		ctx := stream.Context()
 
-		reqID := handleRequestID(ctx)
+		reqID := HandleRequestID(ctx)
 		// add request id to logger
 		addRequestIDToLogger(ctx, reqID)
 

--- a/requestid/requestid.go
+++ b/requestid/requestid.go
@@ -5,26 +5,22 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
-	"github.com/infobloxopen/atlas-app-toolkit/gateway"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/infobloxopen/atlas-app-toolkit/gateway"
 )
 
 // DefaultRequestIDKey is the metadata key name for request ID
 const DefaultRequestIDKey = "Request-Id"
 
-func handleRequestID(ctx context.Context) (reqID string) {
+// HandleRequestID either extracts a existing and valid request ID from the context or generates a new one
+func HandleRequestID(ctx context.Context) (reqID string) {
 	reqID, exists := FromContext(ctx)
-	if !exists {
+	if !exists || reqID == "" {
 		reqID := newRequestID()
 		return reqID
 	}
-
-	if reqID == "" {
-		reqID := newRequestID()
-		return reqID
-	}
-
 	return reqID
 }
 


### PR DESCRIPTION
Small PR to expose the `handleRequestID` function because it is useful.
I could just duplicate the code on my side, but I don't see a strong reason not to expose to function.