### PR TITLE
update grpc to recent version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,13 @@ sudo: required
 services:
   - docker
 go:
-  - "1.9"
   - "1.10"
   - "1.11"
   - "1.12"
   - "1.13"
 
 env:
-  - DEP_VERSION="0.4.1"
+  - DEP_VERSION="0.5.4"
 
 before_install:
   # add dep for dependency management

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:04aea75705cb453e24bf8c1506a24a5a9036537dbc61ddf71d20900d6c7c3ab9"
+  digest = "1:63365cc19727fc5f786d5d95079016b3601120c9699543abae2d5d0bff139109"
   name = "github.com/DATA-DOG/go-sqlmock"
   packages = ["."]
   pruneopts = "UT"
-  revision = "d76b18b42f285b792bf985118980ce9eacea9d10"
-  version = "v1.3.0"
+  revision = "7d7fc89ac4d6e7994c74cf16a6cb774b0374f2f9"
+  version = "v1.4.1"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
@@ -19,17 +19,18 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5771b86b64a5e64d8e3d70337813686586210131ac4fb4c6a97b43c8e25e2253"
+  digest = "1:283c2e79f34b41f444d14c2b7a3cc458d3ff18736e502832eac0a407ebfe6263"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3af4c746e1c248ee8491a3e0c6f7a9cd831e95f8"
+  revision = "dc14462fd58732591c7fa58cc8496d6824316a82"
 
 [[projects]]
   branch = "master"
-  digest = "1:b0add830aeeb55d56127cb60199eca80cbff045ee0cd1ed4b82153fd17288b5b"
+  digest = "1:21a338ab8d56ed1117b46cb9b9021d15d6425650af9da750cddb44e4475e9218"
   name = "github.com/golang/protobuf"
   packages = [
+    "descriptor",
     "jsonpb",
     "proto",
     "protoc-gen-go/descriptor",
@@ -44,18 +45,18 @@
     "ptypes/wrappers",
   ]
   pruneopts = "UT"
-  revision = "7be3631955993a734965532f776bad7093f6fc9d"
+  revision = "d23c5127dc24889085f8ccea5c9d560a57a879d8"
 
 [[projects]]
-  digest = "1:3a26588bc48b96825977c1b3df964f8fd842cd6860cc26370588d3563433cf11"
+  digest = "1:582b704bebaa06b48c29b0cec224a6058a09c86883aaddabde889cd1a5f73e1b"
   name = "github.com/google/uuid"
   packages = ["."]
   pruneopts = "UT"
-  revision = "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
-  version = "v1.0.0"
+  revision = "0cd6bf5da1e1c83f8b45653022c74f71af0538a4"
+  version = "v1.1.1"
 
 [[projects]]
-  digest = "1:c99635434bee2cce9e75a864ca17f8085fcdd43cd564057b431ee01aef2bdd12"
+  digest = "1:55a4db28a494118f80b5edc5df24d28a292f2743fbef51d870e59133e41a6ea5"
   name = "github.com/grpc-ecosystem/go-grpc-middleware"
   packages = [
     ".",
@@ -64,64 +65,64 @@
     "logging/logrus",
     "logging/logrus/ctxlogrus",
     "tags",
-    "tags/logrus",
     "util/metautils",
   ]
   pruneopts = "UT"
-  revision = "c250d6563d4d4c20252cd865923440e829844f4e"
-  version = "v1.0.0"
+  revision = "3c51f7f332123e8be5a157c0802a228ac85bf9db"
+  version = "v1.2.0"
 
 [[projects]]
-  digest = "1:36d8bdf4367306ad70e7fb62c6cd6735a3c448a5ef3ac912b384fd143a36ff3a"
+  digest = "1:cacc4e85cbba0033e53a4c08aed0af00e253263216e88dd7dc2cba3732674ec3"
   name = "github.com/grpc-ecosystem/grpc-gateway"
   packages = [
+    "internal",
     "protoc-gen-swagger/options",
     "runtime",
-    "runtime/internal",
     "utilities",
   ]
   pruneopts = "UT"
-  revision = "92583770e3f01b09a0d3e9bdf64321d8bebd48f2"
-  version = "v1.4.1"
+  revision = "4c2cec4158f65aebe0290d3bee883b13f7b07c6f"
+  version = "v1.13.0"
 
 [[projects]]
-  digest = "1:6895fbe5a10c5aebd1965cac6f6905dcdb21bee01e08912d3ba6a805c2485f6a"
+  digest = "1:e40b74b04fa9a70ff39869139c9fd15ec9a9eefde3f51ef3b65405a60ce30e0e"
   name = "github.com/jinzhu/gorm"
   packages = [
     ".",
     "dialects/postgres",
   ]
   pruneopts = "UT"
-  revision = "6ed508ec6a4ecb3531899a69cbc746ccf65a4166"
-  version = "v1.9.1"
+  revision = "79a77d771dee4e4b60e9c543e8663bbc80466670"
+  version = "v1.9.12"
 
 [[projects]]
-  branch = "master"
-  digest = "1:fd97437fbb6b7dce04132cf06775bd258cce305c44add58eb55ca86c6c325160"
+  digest = "1:01ed62f8f4f574d8aff1d88caee113700a2b44c42351943fa73cc1808f736a50"
   name = "github.com/jinzhu/inflection"
   packages = ["."]
   pruneopts = "UT"
-  revision = "04140366298a54a039076d798123ffa108fff46c"
+  revision = "f5c5f50e6090ae76a29240b61ae2a90dd810112e"
+  version = "v1.0.0"
 
 [[projects]]
-  digest = "1:0a69a1c0db3591fcefb47f115b224592c8dfa4368b7ba9fae509d5e16cdc95c8"
+  digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
   pruneopts = "UT"
-  revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
-  version = "v1.0.1"
+  revision = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e"
+  version = "v1.0.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:eccb7932085ab3d943b3272216bbe1cbbdc5a06a6056d6c2b0ea0cf7f0519e6d"
+  digest = "1:94a02ba66dd163fc2b516b374ad72bbbc68a70e3f6f6ac6bba54f27facd70cc8"
   name = "github.com/lib/pq"
   packages = [
     ".",
     "hstore",
     "oid",
+    "scram",
   ]
   pruneopts = "UT"
-  revision = "9eb73efc1fcc404148b56765b0d3f61d9a5ef8ee"
+  revision = "9eb3fc897d6fd97dd4aad3d0404b54e2f7cc56be"
 
 [[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
@@ -132,32 +133,24 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:87c2e02fb01c27060ccc5ba7c5a407cc91147726f8f40b70cceeedbc52b1f3a8"
+  digest = "1:04457f9f6f3ffc5fea48e71d62f2ca256637dee0a04d710288e27e05c8b41976"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e1e72e9de974bd926e5c56f83753fba2df402ce5"
-  version = "v1.3.0"
+  revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
+  version = "v1.4.2"
 
 [[projects]]
-  digest = "1:18752d0b95816a1b777505a97f71c7467a8445b8ffb55631a7bf779f6ba4fa83"
+  digest = "1:5e8f46b412421d2d6cceea845d28ac46f3f5a5f60a6e86f0ee75e24fd43a02a9"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
   pruneopts = "UT"
-  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
-  version = "v1.2.2"
+  revision = "3ebf1ddaeb260c4b1ae502a01c7844fa8c1fa0e9"
+  version = "v1.5.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
-  name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
-  pruneopts = "UT"
-  revision = "0c41d7ab0a0ee717d4590a44bcb987dfd9e183eb"
-
-[[projects]]
-  branch = "master"
-  digest = "1:505dbee0833715a72a529bb57c354826ad42a4496fad787fa143699b4de1a6d0"
+  digest = "1:d60f1958ca4a7a5eb327a5f742777f1d238f78f9722a32cd12a7dc0311e1f50d"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -169,27 +162,26 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "04a2e542c03f1d053ab3e4d6e5abcd4b66e2be8e"
+  revision = "5a598a2470a0279bd28bab287167dc1ef0813153"
 
 [[projects]]
   branch = "master"
-  digest = "1:db09bef7e2c1a744c896d1f812eb7f08c1b13828edff7d7b6dd8a7f2e504e87f"
+  digest = "1:578046baf093df15df2904bbb0fe06f3f2385bad59987532201007754aa7e1d5"
   name = "golang.org/x/sys"
-  packages = [
-    "unix",
-    "windows",
-  ]
+  packages = ["unix"]
   pruneopts = "UT"
-  revision = "8b8824e799c8fc8e6d900615cc6c761ce6c26c67"
+  revision = "d5e6a3e2c0ae16fc7480523ebcb7fd4dd3215489"
 
 [[projects]]
-  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
+  digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
   name = "golang.org/x/text"
   packages = [
     "collate",
     "collate/build",
     "internal/colltab",
     "internal/gen",
+    "internal/language",
+    "internal/language/compact",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
@@ -202,55 +194,75 @@
     "unicode/rangetable",
   ]
   pruneopts = "UT"
-  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
-  version = "v0.3.0"
+  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
+  version = "v0.3.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:99c78803152bb77d5cfb7d7c903d5c99c3db256185da066c3f9d17ced45938b1"
+  digest = "1:25dad67dc6fea69360a2d493ce289ff01af18de4b8029b930cc290e4131679c3"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/annotations",
+    "googleapis/api/httpbody",
     "googleapis/rpc/code",
     "googleapis/rpc/status",
     "protobuf/field_mask",
   ]
   pruneopts = "UT"
-  revision = "94acd270e44e65579b9ee3cdab25034d33fed608"
+  revision = "e50cd9704f63023d62cd06a1994b98227fc4d21a"
 
 [[projects]]
-  digest = "1:2dab32a43451e320e49608ff4542fdfc653c95dcc35d0065ec9c6c3dd540ed74"
+  digest = "1:de21a2d5b9c8697d83f5ab48f3e8fe3616c33ac4b2d057083662dede0e81488e"
   name = "google.golang.org/grpc"
   packages = [
     ".",
+    "attributes",
+    "backoff",
     "balancer",
     "balancer/base",
     "balancer/roundrobin",
+    "binarylog/grpc_binarylog_v1",
     "codes",
     "connectivity",
     "credentials",
+    "credentials/internal",
     "encoding",
     "encoding/proto",
     "grpclog",
     "internal",
     "internal/backoff",
+    "internal/balancerload",
+    "internal/binarylog",
+    "internal/buffer",
     "internal/channelz",
+    "internal/envconfig",
     "internal/grpcrand",
+    "internal/grpcsync",
+    "internal/resolver/dns",
+    "internal/resolver/passthrough",
+    "internal/syscall",
+    "internal/transport",
     "keepalive",
     "metadata",
     "naming",
     "peer",
     "resolver",
-    "resolver/dns",
-    "resolver/passthrough",
+    "serviceconfig",
     "stats",
     "status",
     "tap",
-    "transport",
   ]
   pruneopts = "UT"
-  revision = "168a6198bcb0ef175f7dacec0b8691fc141dc9b8"
-  version = "v1.13.0"
+  revision = "f495f5b15ae7ccda3b38c53a1bfcde4c1a58a2bc"
+  version = "v1.27.1"
+
+[[projects]]
+  digest = "1:55b110c99c5fdc4f14930747326acce56b52cfce60b24b1c03ef686ac0e46bb1"
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "53403b58ad1b561927d19068c655246f2db79d48"
+  version = "v2.2.8"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -286,7 +298,6 @@
     "google.golang.org/grpc/grpclog",
     "google.golang.org/grpc/metadata",
     "google.golang.org/grpc/status",
-    "google.golang.org/grpc/transport",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -209,7 +209,7 @@
     "protobuf/field_mask",
   ]
   pruneopts = "UT"
-  revision = "e50cd9704f63023d62cd06a1994b98227fc4d21a"
+  revision = "fc8f554266884563332e03c40daaf5db88ecce10"
 
 [[projects]]
   digest = "1:de21a2d5b9c8697d83f5ab48f3e8fe3616c33ac4b2d057083662dede0e81488e"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "github.com/grpc-ecosystem/go-grpc-middleware"
-  version = "1.0.0"
+  version = ">=1.0.0"
 
 [[constraint]]
   branch = "master"
@@ -16,15 +16,15 @@
 
 [[constraint]]
   name = "github.com/grpc-ecosystem/grpc-gateway"
-  version = "1.4.1"
+  version = ">=1.13.0"
 
 [[override]]
   name = "github.com/lyft/protoc-gen-validate"
-  version = "0.0.7"
+  version = ">=0.0.7"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"
-  version = "1.2.0"
+  version = ">=1.0.0"
 
 [[constraint]]
   branch = "master"
@@ -36,7 +36,7 @@
 
 [[constraint]]
   name = "google.golang.org/grpc"
-  version = "1.11.0"
+  version = ">=1.0.0"
 
 [prune]
   go-tests = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -16,7 +16,7 @@
 
 [[constraint]]
   name = "github.com/grpc-ecosystem/grpc-gateway"
-  version = ">=1.13.0"
+  version = ">=1.4.1"
 
 [[override]]
   name = "github.com/lyft/protoc-gen-validate"

--- a/errors/mappers/validationerrors/interceptor_test.go
+++ b/errors/mappers/validationerrors/interceptor_test.go
@@ -7,13 +7,20 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"google.golang.org/grpc/transport"
 )
+
+type DummyTransportStream struct{}
+
+func (*DummyTransportStream) Method() string                  { return "unimplemented" }
+func (*DummyTransportStream) SetHeader(md metadata.MD) error  { return nil }
+func (*DummyTransportStream) SendHeader(md metadata.MD) error { return nil }
+func (*DummyTransportStream) SetTrailer(md metadata.MD) error { return nil }
 
 // DummyContextWithServerTransportStream returns a dummy context for testing.
 func DummyContextWithServerTransportStream() context.Context {
-	expectedStream := &transport.Stream{}
+	expectedStream := &DummyTransportStream{}
 	return grpc.NewContextWithServerTransportStream(context.Background(), expectedStream)
 }
 

--- a/gateway/response.go
+++ b/gateway/response.go
@@ -10,7 +10,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/grpclog"
 
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	runtime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 )
 
 type (
@@ -134,6 +134,11 @@ func (fw *ResponseForwarder) ForwardMessage(ctx context.Context, mux *runtime.Se
 	handleForwardResponseTrailer(rw, md)
 }
 
+type delimited interface {
+	// Delimiter returns the record seperator for the stream.
+	Delimiter() []byte
+}
+
 // ForwardStream implements runtime.ForwardResponseStreamFunc.
 // RestStatus comes first in the chuncked result.
 func (fw *ResponseForwarder) ForwardStream(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, rw http.ResponseWriter, req *http.Request, recv func() (proto.Message, error), opts ...func(context.Context, http.ResponseWriter, proto.Message) error) {
@@ -169,7 +174,7 @@ func (fw *ResponseForwarder) ForwardStream(ctx context.Context, mux *runtime.Ser
 	rw.WriteHeader(httpStatus)
 
 	var delimiter []byte
-	if d, ok := marshaler.(runtime.Delimited); ok {
+	if d, ok := marshaler.(delimited); ok {
 		delimiter = d.Delimiter()
 	} else {
 		delimiter = []byte("\n")


### PR DESCRIPTION
```
[0] rm-ml-dgarcia:~/go/src/github.com/infobloxopen/atlas-app-toolkit$ make test
test -z `go fmt ./...`
dep ensure
go test -cover ./...
ok  	github.com/infobloxopen/atlas-app-toolkit/auth	(cached)	coverage: 82.9% of statements
ok  	github.com/infobloxopen/atlas-app-toolkit/errors	(cached)	coverage: 83.6% of statements
ok  	github.com/infobloxopen/atlas-app-toolkit/errors/mappers/pqerrors	(cached)	coverage: 100.0% of statements
ok  	github.com/infobloxopen/atlas-app-toolkit/errors/mappers/validationerrors	(cached)	coverage: 93.0% of statements
ok  	github.com/infobloxopen/atlas-app-toolkit/gateway	(cached)	coverage: 65.0% of statements
ok  	github.com/infobloxopen/atlas-app-toolkit/gorm	(cached)	coverage: 85.1% of statements
ok  	github.com/infobloxopen/atlas-app-toolkit/gorm/resource	(cached)	coverage: 95.8% of statements
ok  	github.com/infobloxopen/atlas-app-toolkit/health	(cached)	coverage: 87.5% of statements
ok  	github.com/infobloxopen/atlas-app-toolkit/integration	(cached)	coverage: 70.0% of statements
ok  	github.com/infobloxopen/atlas-app-toolkit/logging	(cached)	coverage: 25.5% of statements
ok  	github.com/infobloxopen/atlas-app-toolkit/query	(cached)	coverage: 49.2% of statements
ok  	github.com/infobloxopen/atlas-app-toolkit/requestid	(cached)	coverage: 96.6% of statements
ok  	github.com/infobloxopen/atlas-app-toolkit/requestinfo	(cached)	coverage: 83.6% of statements
ok  	github.com/infobloxopen/atlas-app-toolkit/rpc/errdetails	(cached)	coverage: 67.4% of statements
ok  	github.com/infobloxopen/atlas-app-toolkit/rpc/errfields	(cached)	coverage: 19.1% of statements
ok  	github.com/infobloxopen/atlas-app-toolkit/rpc/resource	(cached)	coverage: 78.7% of statements
ok  	github.com/infobloxopen/atlas-app-toolkit/server	(cached)	coverage: 74.6% of statements
?   	github.com/infobloxopen/atlas-app-toolkit/servertest	[no test files]
ok  	github.com/infobloxopen/atlas-app-toolkit/util	(cached)	coverage: 100.0% of statements
```