### PR TITLE
Begin transaction with options.

### DIFF
--- a/gorm/transaction.go
+++ b/gorm/transaction.go
@@ -57,6 +57,10 @@ func (t *Transaction) AddAfterCommitHook(hooks ...func(context.Context)) {
 	t.afterCommitHook = append(t.afterCommitHook, hooks...)
 }
 
+// BeginFromContext will extract transaction wrapper from context and start new transaction.
+// As result new instance of `*gorm.DB` will be returned.
+// Error will be returned in case either transaction or db connection info is missing in context.
+// Gorm specific error can be checked by `*gorm.DB.Error`.
 func BeginFromContext(ctx context.Context) (*gorm.DB, error) {
 	txn, ok := FromContext(ctx)
 	if !ok {
@@ -72,6 +76,11 @@ func BeginFromContext(ctx context.Context) (*gorm.DB, error) {
 	return db, nil
 }
 
+// BeginWithOptionsFromContext will extract transaction wrapper from context and start new transaction,
+// options can be specified to control isolation level for transaction.
+// As result new instance of `*gorm.DB` will be returned.
+// Error will be returned in case either transaction or db connection info is missing in context.
+// Gorm specific error can be checked by `*gorm.DB.Error`.
 func BeginWithOptionsFromContext(ctx context.Context, opts *sql.TxOptions) (*gorm.DB, error) {
 	txn, ok := FromContext(ctx)
 	if !ok {


### PR DESCRIPTION
  * Extended `Transaction` object with support of beginning transaction with
    options (to be able to set isolation level and RO option). Added
    `gorm.BeginTx()` wrapper;
  * Added analog wrapper to do same thing while extracting txn from context;
  * Updated UTs.

*Notes:*
1. `BeginWithOptions` used as name for new function while it wraps `gorm.BeginTx` maybe using `BeginTx` is preferable;
2. Aforementioned function only accept options and uses background context, based on [doc](https://golang.org/pkg/database/sql/#DB.BeginTx) this context (when cancelled) may be used to rollback transaction and prevent commit. I'm not sure if it should be exposed;  
3. `gorm/README.md` was not updated please let me know if it is required to change anything in it.

Verified with `make test`.
