### PR TITLE
update Go deps with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: "/tools/debugging"
+    schedule:
+      interval: daily
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
This enables Dependabot for this repos Go dependencies.