### PR TITLE
Added hashid support to blox resource id

### DIFF
--- a/bloxid/hashids.go
+++ b/bloxid/hashids.go
@@ -1,0 +1,110 @@
+package bloxid
+
+import (
+	"errors"
+
+	hashids "github.com/speps/go-hashids/v2"
+)
+
+const (
+	hashIDAllowedChar = "0123456789abcdef"
+
+	//the prefix needs to be uppercase so there are no collisions with chars in hashIDAllowedChar
+	hashIDPrefix = "HIDZ"
+
+	idSchemeHashID = "hashid"
+)
+
+var (
+	ErrInvalidSalt = errors.New("invalid salt")
+	ErrInvalidID   = errors.New("invalid id")
+
+	maxHashIDLen = DefaultUniqueIDDecodedCharSize - len(hashIDPrefix)
+
+	hashIDPrefixBytes = []byte(hashIDPrefix)
+)
+
+func newHashID(salt string) (*hashids.HashID, error) {
+	hid := hashids.HashIDData{
+		Alphabet:  hashIDAllowedChar,
+		MinLength: maxHashIDLen,
+		Salt:      salt,
+	}
+
+	return hashids.NewWithData(&hid)
+}
+
+func validateGetHashID(id int64, salt string) error {
+
+	if len(salt) < 1 {
+		return ErrInvalidSalt
+	}
+
+	if id < 0 {
+		return ErrInvalidID
+	}
+
+	return nil
+}
+
+func getHashID(id int64, salt string) (string, error) {
+	if err := validateGetHashID(id, salt); err != nil {
+		return "", err
+	}
+
+	h, err := newHashID(salt)
+	if err != nil {
+		return "", err
+	}
+
+	eID, err := h.EncodeInt64([]int64{id})
+	if err != nil {
+		return "", err
+	}
+
+	return eID, err
+}
+
+func validateGetint64FromHashID(id, salt string) error {
+
+	if len(salt) < 1 {
+		return ErrInvalidSalt
+	}
+
+	if len(id) != maxHashIDLen {
+		return ErrInvalidID
+	}
+
+	return nil
+}
+
+func getInt64FromHashID(id, salt string) (int64, error) {
+	if err := validateGetint64FromHashID(id, salt); err != nil {
+		return -1, err
+	}
+
+	h, err := newHashID(salt)
+	if err != nil {
+		return -1, err
+	}
+
+	dID, err := h.DecodeInt64WithError(id)
+	if err != nil {
+		return -1, err
+	}
+
+	return dID[0], err
+}
+
+func WithHashIDInt64(id int64) func(o *V0Options) {
+	return func(o *V0Options) {
+		o.hashIDInt64 = id
+		o.scheme = idSchemeHashID
+	}
+}
+
+func WithHashIDSalt(salt string) func(o *V0Options) {
+	return func(o *V0Options) {
+		o.hashidSalt = salt
+	}
+}

--- a/bloxid/hashids_test.go
+++ b/bloxid/hashids_test.go
@@ -1,0 +1,328 @@
+package bloxid
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHashIDtoInt(t *testing.T) {
+	var tests = []struct {
+		name    string
+		hashID  string
+		int64ID int64
+		salt    string
+		err     error
+	}{
+		{
+			name:    "Valid input",
+			hashID:  "blox0.infra.host.us-com-1.jbeuiwrsmq3tkmzwmuzwcojsmrqwemrtgy3tqzbvhbsdizjvhe2dkn3cgzrdizlb",
+			int64ID: 1,
+			salt:    "test",
+			err:     nil,
+		},
+		{
+			name:    "Different salt",
+			hashID:  "blox0.infra.host.us-com-1.jbeuiwrsmq3tkmzwmuzwcojsmrqwemrtgy3tqzbvhbsdizjvhe2dkn3cgzrdizlb",
+			int64ID: -1,
+			salt:    "testi1",
+			err:     errors.New("mismatch between encode and decode: 2d7536e3a92dab23678d58d4e59457b6b4ea start ed4b2a9764524ed6958d58237ba3eadb7695 re-encoded. result: [4]"),
+		},
+
+		{
+			name:    "Invalid prefix HIDA with correct int value",
+			hashID:  "blox0.infra.host.us-com-1.jbeuiqjsmq3tkmzwmuzwcojsmrqwemrtgy3tqzbvhbsdizjvhe2dkn3cgzrdizlb",
+			int64ID: -1,
+			salt:    "test",
+			err:     nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			v0_1, err := NewV0(test.hashID, WithHashIDSalt(test.salt))
+
+			assert.Equal(t, test.err, err)
+			assert.Equal(t, test.int64ID, v0_1.HashIDInt64())
+		})
+	}
+}
+
+func TestHashIDInttoInt(t *testing.T) {
+	var tests = []struct {
+		name       string
+		int64ID    int64
+		entityType string
+		domainType string
+		realm      string
+		salt       string
+		err        error
+	}{
+		{
+			name:       "Valid input",
+			int64ID:    1,
+			entityType: "hostapp",
+			domainType: "infra",
+			realm:      "us-com-1",
+			salt:       "test",
+			err:        nil,
+		},
+		{
+			name:       "Negative number",
+			int64ID:    -1,
+			entityType: "hostapp",
+			domainType: "infra",
+			realm:      "us-com-1",
+			salt:       "test",
+			err:        ErrInvalidID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			v0, err := NewV0("",
+				WithEntityDomain(test.domainType),
+				WithEntityType(test.entityType),
+				WithRealm(test.realm),
+				WithHashIDInt64(test.int64ID),
+				WithHashIDSalt(test.salt))
+
+			assert.Equal(t, test.err, err)
+
+			if err == nil {
+				v0_1, err := NewV0(v0.String(), WithHashIDSalt(test.salt))
+
+				assert.Equal(t, test.err, err)
+				assert.Equal(t, test.int64ID, v0_1.HashIDInt64())
+				assert.Equal(t, v0, v0_1)
+			}
+		})
+	}
+}
+
+func TestGetHashID(t *testing.T) {
+	var tests = []struct {
+		name    string
+		int64ID int64
+		salt    string
+		hashID  string
+		err     error
+	}{
+		{
+			name:    "Valid input",
+			int64ID: 1,
+			salt:    "test",
+			hashID:  "2d7536e3a92dab23678d58d4e59457b6b4ea",
+			err:     nil,
+		},
+		{
+			name:    "zero number",
+			int64ID: 0,
+			salt:    "test",
+			hashID:  "e735d27d4a5e57d3648658a92be26b93b46a",
+			err:     nil,
+		},
+		{
+			name:    "negative number",
+			int64ID: -1,
+			salt:    "test1",
+			hashID:  "",
+			err:     ErrInvalidID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			hashID, err := getHashID(test.int64ID, test.salt)
+			assert.Equal(t, test.err, err)
+			assert.Equal(t, test.hashID, hashID)
+		})
+	}
+}
+
+func TestGetIntFromHashID(t *testing.T) {
+	var tests = []struct {
+		name    string
+		int64ID int64
+		salt    string
+		hashID  string
+		err     error
+	}{
+		{
+			name:    "Valid input",
+			int64ID: 1,
+			salt:    "test",
+			hashID:  "2d7536e3a92dab23678d58d4e59457b6b4ea",
+			err:     nil,
+		},
+		{
+			name:    "negative number",
+			int64ID: -1,
+			salt:    "test1",
+			hashID:  "",
+			err:     ErrInvalidID,
+		},
+		{
+			name:    "empty hash",
+			int64ID: -1,
+			salt:    "test1",
+			hashID:  "",
+			err:     ErrInvalidID,
+		},
+		{
+			name:    "zero value",
+			int64ID: 0,
+			salt:    "test",
+			hashID:  "e735d27d4a5e57d3648658a92be26b93b46a",
+			err:     nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			int64ID, err := getInt64FromHashID(test.hashID, test.salt)
+			assert.Equal(t, test.err, err)
+			assert.Equal(t, test.int64ID, int64ID)
+		})
+	}
+}
+
+func TestGenerateNewV0(t *testing.T) {
+	var testmap = []struct {
+		realm        string
+		entityDomain string
+		entityType   string
+		hashIntID    int64
+		expected     string
+		err          error
+	}{
+		// ensure `=` is not part of id when encoded
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			hashIntID:    1,
+			expected:     "blox0.infra.host.us-com-1.ivmfiurreaqcaiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			hashIntID:    12,
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiqcaiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			hashIntID:    123,
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgizsaiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			hashIntID:    1234,
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztiiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			hashIntID:    12345,
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztinja",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			hashIntID:    123456,
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztinjweaqcaiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			hashIntID:    1234567,
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztinjwg4qcaiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			hashIntID:    12345678,
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztinjwg44caiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			hashIntID:    123456789,
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztinjwg44dsiba",
+		},
+	}
+
+	for index, tm := range testmap {
+		index++
+		v0, err := NewV0("",
+			WithEntityDomain(tm.entityDomain),
+			WithEntityType(tm.entityType),
+			WithRealm(tm.realm),
+			WithHashIDInt64(tm.hashIntID),
+			WithHashIDSalt("test"),
+		)
+		if err != tm.err {
+			//			t.Logf("test: %#v", tm)
+			t.Errorf("index: %d got: %s wanted error: %s", index, err, tm.err)
+		}
+		if err != nil {
+			continue
+		}
+
+		if v0 == nil {
+			t.Errorf("unexpected nil id")
+			continue
+		}
+
+		if -1 != strings.Index(v0.String(), "=") {
+			t.Errorf("got: %q wanted bloxid without equal char", v0.String())
+		}
+	}
+}
+
+/*
+func TestHashIDUniqueness(t *testing.T) {
+
+	var salt string = "test"
+	var maxIntVal int64 = math.MaxInt64
+	var i int64
+
+	checkUniq := make(map[string]struct{})
+	for i = 0; i < maxIntVal; i++ {
+		v0, err := NewV0("",
+			WithHashIDInt64(i),
+			WithHashIDSalt(salt),
+		)
+		if err != nil {
+			t.Errorf("Failed to convert int to hash id. Index: %v\n", i)
+			continue
+		}
+
+		if _, ok := checkUniq[v0.EncodedID()]; ok {
+			fmt.Printf("The value is not unique for index: %d - hashid: %s\n", i, v0.EncodedID())
+		} else {
+			checkUniq[v0.EncodedID()] = struct{}{}
+		}
+
+		if -1 != strings.Index(v0.EncodedID(), "=") {
+			fmt.Printf("id has equal sign: index %v hashID %v\n", i, v0.EncodedID())
+		}
+		if i%1000000 == 0 {
+			fmt.Printf("Completed: %v\n", i)
+		}
+	}
+	fmt.Println(i)
+}
+*/

--- a/bloxid/interface.go
+++ b/bloxid/interface.go
@@ -15,7 +15,9 @@ type ID interface {
 	// the resource is found in ie. `us-com-1`, `eu-com-1`, ...
 	Realm() string
 	// EncodedID returns the unique id in encoded format
-	// TODO: EncodedID() string
+	EncodedID() string
 	// DecodedID returns the unique id in decoded format
-	// TODO: DecodedID() string
+	DecodedID() string
+	// Return the id scheme
+	Scheme() string
 }

--- a/bloxid/v0_test.go
+++ b/bloxid/v0_test.go
@@ -14,14 +14,16 @@ func TestNewV0(t *testing.T) {
 		decoded      string
 		err          error
 	}{
-		{
-			"",
-			"",
-			"",
-			"",
-			"",
-			ErrIDEmpty,
-		},
+		/*
+			{
+				"",
+				"",
+				"",
+				"",
+				"",
+				ErrIDEmpty,
+			},
+		*/
 		{
 			input: "bloxv0....",
 			err:   ErrInvalidVersion,
@@ -48,27 +50,27 @@ func TestNewV0(t *testing.T) {
 		},
 	}
 
-	for _, tm := range testmap {
+	for index, tm := range testmap {
 		v0, err := NewV0(tm.input)
 		if err != tm.err {
 			t.Log(tm.input)
-			t.Errorf("got: %s wanted: %s", err, tm.err)
+			t.Errorf("index: %d got: %s wanted: %s", index, err, tm.err)
 		}
 		if err != nil {
 			continue
 		}
 		if v0.String() != tm.output {
-			t.Errorf("got: %s wanted: %s", v0.String(), tm.output)
+			t.Errorf("index: %d got: %s wanted: %s", index, v0.String(), tm.output)
 		}
 
 		if v0.entityDomain != tm.entityDomain {
-			t.Errorf("got: %q wanted: %q", v0.entityDomain, tm.entityDomain)
+			t.Errorf("index: %d got: %q wanted: %q", index, v0.entityDomain, tm.entityDomain)
 		}
 		if v0.entityType != tm.entityType {
-			t.Errorf("got: %q wanted: %q", v0.entityType, tm.entityType)
+			t.Errorf("index: %d got: %q wanted: %q", index, v0.entityType, tm.entityType)
 		}
 		if v0.decoded != tm.decoded {
-			t.Errorf("got: %q wanted: %q", v0.decoded, tm.decoded)
+			t.Errorf("index: %d got: %q wanted: %q", index, v0.decoded, tm.decoded)
 		}
 	}
 }
@@ -89,12 +91,14 @@ func TestGenerateV0(t *testing.T) {
 			entityDomain: "infra",
 			entityType:   "host",
 			expected:     "blox0.infra.host.us-com-1.",
+			err:          ErrEmptyExtrinsicID,
 		},
 		{
 			realm:        "us-com-2",
 			entityDomain: "infra",
 			entityType:   "host",
 			expected:     "blox0.infra.host.us-com-2.",
+			err:          ErrEmptyExtrinsicID,
 		},
 
 		// ensure `=` is not part of id when encoded
@@ -163,17 +167,16 @@ func TestGenerateV0(t *testing.T) {
 		},
 	}
 
-	for _, tm := range testmap {
-		v0, err := GenerateV0(&V0Options{
-			EntityDomain: tm.entityDomain,
-			EntityType:   tm.entityType,
-			Realm:        tm.realm,
-		},
+	for index, tm := range testmap {
+		v0, err := NewV0("",
+			WithEntityDomain(tm.entityDomain),
+			WithEntityType(tm.entityType),
+			WithRealm(tm.realm),
 			WithExtrinsicID(tm.extrinsicID),
 		)
 		if err != tm.err {
 			t.Logf("test: %#v", tm)
-			t.Errorf("got: %s wanted error: %s", err, tm.err)
+			t.Errorf("index: %d got: %s wanted error: %s", index, err, tm.err)
 		}
 		if err != nil {
 			continue
@@ -184,8 +187,8 @@ func TestGenerateV0(t *testing.T) {
 			continue
 		}
 
-		t.Log(v0)
-		t.Logf("%#v\n", v0)
+		//		t.Log(v0)
+		//		t.Logf("%#v\n", v0)
 
 		validateGenerateV0(t, tm, v0, err)
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0
 	github.com/lib/pq v1.3.1-0.20200116171513-9eb3fc897d6f
 	github.com/sirupsen/logrus v1.8.0
+	github.com/speps/go-hashids/v2 v2.0.1
 	github.com/stretchr/testify v1.5.1
 	go.opencensus.io v0.22.3
 	golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.8.0 h1:nfhvjKcUMhBMVqbKHJlk5RPrrfYr/NMo3692g0dwfWU=
 github.com/sirupsen/logrus v1.8.0/go.mod h1:4GuYW9TZmE769R5STWrRakJc4UqQ3+QQ95fyz7ENv1A=
+github.com/speps/go-hashids/v2 v2.0.1 h1:ViWOEqWES/pdOSq+C1SLVa8/Tnsd52XC34RY7lt7m4g=
+github.com/speps/go-hashids/v2 v2.0.1/go.mod h1:47LKunwvDZki/uRVD6NImtyk712yFzIs3UF3KlHohGw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
Services can convert the integer id to hashid and vice vera.

New the hash id = `HIDZ` + `hashid`

Int id to hashid:
Input: int64 id and salt
```
v0, err := NewV0("",
            WithEntityDomain("infra"),
            WithEntityType("host"),
            WithRealm("us-com-1"),
            WithHashIDInt64(1),
            WithHashIDSalt("test"),
        )

Output: blox0.infra.host.us-com-1.jbeuiwrsmq3tkmzwmuzwcojsmrqwemrtgy3tqzbvhbsdizjvhe2dkn3cgzrdizlb
Decoded hash-id(v0.Decoded()): 2d7536e3a92dab23678d58d4e59457b6b4ea 
```
Hashid to int64 id: 
Input: hashid and salt:
```
parsed, err := NewV0("blox0.infra.host.us-com-1.jbeuiwrsmq3tkmzwmuzwcojsmrqwemrtgy3tqzbvhbsdizjvhe2dkn3cgzrdizlb", WithHashIDSalt("test"))
parsed.HashInt64ID() -> 1
parsed.DecodedID() -> "1"
```