### PR TITLE
GH-268: rename ShortID() with ExtrinsicID() to indicate decoded UniqueID is supplied instead of randomly generated

### DIFF
--- a/bloxid/extrinsicids.go
+++ b/bloxid/extrinsicids.go
@@ -1,0 +1,41 @@
+package bloxid
+
+import (
+	"errors"
+	"regexp"
+)
+
+const (
+	extrinsicIDPrefix = "EXTR" //the prefix needs to be uppercase
+)
+
+var (
+	extrinsicIDPrefixBytes = []byte(extrinsicIDPrefix)
+)
+
+var (
+	ErrEmptyExtrinsicID   = errors.New("empty extrinsic id")
+	ErrInvalidExtrinsicID = errors.New("invalid extrinsic id")
+
+	extrinsicIDRegex = regexp.MustCompile(`^[0-9A-Za-z_-]+$`)
+)
+
+func validateGetExtrinsicID(id string) error {
+	if len(id) < 1 {
+		return ErrEmptyExtrinsicID
+	}
+
+	if !extrinsicIDRegex.MatchString(id) {
+		return ErrInvalidExtrinsicID
+	}
+
+	return nil
+}
+
+func getExtrinsicID(id string) (string, error) {
+	if err := validateGetExtrinsicID(id); err != nil {
+		return "", err
+	}
+
+	return id, nil
+}

--- a/bloxid/interface.go
+++ b/bloxid/interface.go
@@ -4,8 +4,6 @@ package bloxid
 type ID interface {
 	// String returns the complete resource ID
 	String() string
-	// ShortID returns a shortened ID that will be locally unique
-	ShortID() string
 	// Version returns a serialized representation of the ID version
 	// ie. `V0`
 	Version() string // V0
@@ -16,4 +14,8 @@ type ID interface {
 	// Realm is optional and returns the cloud realm that
 	// the resource is found in ie. `us-com-1`, `eu-com-1`, ...
 	Realm() string
+	// EncodedID returns the unique id in encoded format
+	// TODO: EncodedID() string
+	// DecodedID returns the unique id in decoded format
+	// TODO: DecodedID() string
 }

--- a/bloxid/v0_test.go
+++ b/bloxid/v0_test.go
@@ -73,20 +73,93 @@ func TestNewV0(t *testing.T) {
 	}
 }
 
+type generateTestCase struct {
+	realm        string
+	entityDomain string
+	entityType   string
+	extrinsicID  string
+	expected     string
+	err          error
+}
+
 func TestGenerateV0(t *testing.T) {
-	var testmap = []struct {
-		realm          string
-		entityDomain   string
-		entityType     string
-		output         string
-		expectedPrefix string
-		err            error
-	}{
+	var testmap = []generateTestCase{
 		{
-			realm:          "us-com-1",
-			entityDomain:   "infra",
-			entityType:     "host",
-			expectedPrefix: "blox0.infra.host.us-com-1.",
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			expected:     "blox0.infra.host.us-com-1.",
+		},
+		{
+			realm:        "us-com-2",
+			entityDomain: "infra",
+			entityType:   "host",
+			expected:     "blox0.infra.host.us-com-2.",
+		},
+
+		// ensure `=` is not part of id when encoded
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "1",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurreaqcaiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "12",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiqcaiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "123",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgizsaiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "1234",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztiiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "12345",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztinja",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "123456",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztinjweaqcaiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "1234567",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztinjwg4qcaiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "12345678",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztinjwg44caiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "123456789",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztinjwg44dsiba",
 		},
 	}
 
@@ -95,23 +168,73 @@ func TestGenerateV0(t *testing.T) {
 			EntityDomain: tm.entityDomain,
 			EntityType:   tm.entityType,
 			Realm:        tm.realm,
-		})
+		},
+			WithExtrinsicID(tm.extrinsicID),
+		)
 		if err != tm.err {
-			t.Errorf("got: %s wanted: %s", err, tm.err)
+			t.Logf("test: %#v", tm)
+			t.Errorf("got: %s wanted error: %s", err, tm.err)
 		}
 		if err != nil {
 			continue
 		}
 
 		if v0 == nil {
-			t.Errorf("unexpected nil version")
+			t.Errorf("unexpected nil id")
 			continue
 		}
 
-		if strings.HasPrefix(tm.expectedPrefix, v0.String()) {
-			t.Errorf("got: %q wanted prefix: %q", v0, tm.expectedPrefix)
-		}
 		t.Log(v0)
 		t.Logf("%#v\n", v0)
+
+		validateGenerateV0(t, tm, v0, err)
+
+		parsed, err := NewV0(v0.String())
+		if err != tm.err {
+			t.Logf("test: %#v", tm)
+			t.Errorf("got: %s wanted: %s", err, tm.err)
+		}
+		if err != nil {
+			continue
+		}
+
+		validateGenerateV0(t, tm, parsed, err)
+	}
+}
+
+func validateGenerateV0(t *testing.T, tm generateTestCase, v0 *V0, err error) {
+	if len(tm.extrinsicID) > 0 {
+		if v0.decoded != tm.extrinsicID {
+			t.Errorf("got: %q wanted decoded: %q", v0.decoded, tm.extrinsicID)
+		}
+		if v0.String() != tm.expected {
+			t.Errorf("got: %q wanted bloxid: %q", v0, tm.expected)
+		}
+	} else {
+		if strings.HasPrefix(tm.expected, v0.String()) {
+			t.Errorf("got: %q wanted prefix: %q", v0, tm.expected)
+		}
+		if len(v0.decoded) < 1 {
+			t.Errorf("got: %q wanted non-empty string in decoded", v0.decoded)
+		}
+	}
+
+	if -1 != strings.Index(v0.String(), "=") {
+		t.Errorf("got: %q wanted bloxid without equal char", v0.String())
+	}
+
+	if v0.Realm() != tm.realm {
+		t.Errorf("got: %q wanted realm: %q", v0.Realm(), tm.realm)
+	}
+	if v0.Domain() != tm.entityDomain {
+		t.Errorf("got: %q wanted entity domain: %q", v0.Domain(), tm.entityDomain)
+	}
+	if v0.Type() != tm.entityType {
+		t.Errorf("got: %q wanted entity type: %q", v0.Type(), tm.entityType)
+	}
+	if len(tm.extrinsicID) > 0 {
+		if v0.decoded != tm.extrinsicID {
+			t.Errorf("got: %q wanted extrinsic id: %q", v0.decoded, tm.extrinsicID)
+		}
 	}
 }


### PR DESCRIPTION
### DEMO:
```
                v0, err := GenerateV0(&V0Options{
                        EntityDomain: "infra",
                        EntityType:   "host",
                        Realm:        "us-com-1",
                },      
                        WithExtrinsicID("12345678"),
                ) 
                // v0 ---> "blox0.infra.host.us-com-1.ivmfiurrgiztinjwg44caiba"
                
                parsed, err := NewV0(v0.String())
                // parsed.Decoded() ---> "12345678"
```

no regressions:
```
# wlu@rm-ml-wlu: go test -v
=== RUN   TestRandBytes
--- PASS: TestRandBytes (0.00s)
=== RUN   TestNewV0
--- PASS: TestNewV0 (0.00s)
=== RUN   TestGenerateV0
    v0_test.go:186: blox0.infra.host.us-com-1.znogb442umeuxbe5fzaczubkfqd3ajq6
    v0_test.go:187: &bloxid.V0{version:0x2, realm:"us-com-1", decoded:"cb5c60f39aa3094b849d2e402cd02a2c07b0261e", encoded:"znogb442umeuxbe5fzaczubkfqd3ajq6", entityDomain:"infra", entityType:"host"}
    v0_test.go:186: blox0.infra.host.us-com-2.nuztedx2ywg3bttbkaepyjoyp4talsr5
    v0_test.go:187: &bloxid.V0{version:0x2, realm:"us-com-2", decoded:"6d33320efac58db0ce615008fc25d87f2605ca3d", encoded:"nuztedx2ywg3bttbkaepyjoyp4talsr5", entityDomain:"infra", entityType:"host"}
    v0_test.go:186: blox0.infra.host.us-com-1.ivmfiurreaqcaiba
    v0_test.go:187: &bloxid.V0{version:0x2, realm:"us-com-1", decoded:"1", encoded:"ivmfiurreaqcaiba", entityDomain:"infra", entityType:"host"}
    v0_test.go:186: blox0.infra.host.us-com-1.ivmfiurrgiqcaiba
    v0_test.go:187: &bloxid.V0{version:0x2, realm:"us-com-1", decoded:"12", encoded:"ivmfiurrgiqcaiba", entityDomain:"infra", entityType:"host"}
    v0_test.go:186: blox0.infra.host.us-com-1.ivmfiurrgizsaiba
    v0_test.go:187: &bloxid.V0{version:0x2, realm:"us-com-1", decoded:"123", encoded:"ivmfiurrgizsaiba", entityDomain:"infra", entityType:"host"}
    v0_test.go:186: blox0.infra.host.us-com-1.ivmfiurrgiztiiba
    v0_test.go:187: &bloxid.V0{version:0x2, realm:"us-com-1", decoded:"1234", encoded:"ivmfiurrgiztiiba", entityDomain:"infra", entityType:"host"}
    v0_test.go:186: blox0.infra.host.us-com-1.ivmfiurrgiztinja
    v0_test.go:187: &bloxid.V0{version:0x2, realm:"us-com-1", decoded:"12345", encoded:"ivmfiurrgiztinja", entityDomain:"infra", entityType:"host"}
    v0_test.go:186: blox0.infra.host.us-com-1.ivmfiurrgiztinjweaqcaiba
    v0_test.go:187: &bloxid.V0{version:0x2, realm:"us-com-1", decoded:"123456", encoded:"ivmfiurrgiztinjweaqcaiba", entityDomain:"infra", entityType:"host"}
    v0_test.go:186: blox0.infra.host.us-com-1.ivmfiurrgiztinjwg4qcaiba
    v0_test.go:187: &bloxid.V0{version:0x2, realm:"us-com-1", decoded:"1234567", encoded:"ivmfiurrgiztinjwg4qcaiba", entityDomain:"infra", entityType:"host"}
    v0_test.go:186: blox0.infra.host.us-com-1.ivmfiurrgiztinjwg44caiba
    v0_test.go:187: &bloxid.V0{version:0x2, realm:"us-com-1", decoded:"12345678", encoded:"ivmfiurrgiztinjwg44caiba", entityDomain:"infra", entityType:"host"}
    v0_test.go:186: blox0.infra.host.us-com-1.ivmfiurrgiztinjwg44dsiba
    v0_test.go:187: &bloxid.V0{version:0x2, realm:"us-com-1", decoded:"123456789", encoded:"ivmfiurrgiztinjwg44dsiba", entityDomain:"infra", entityType:"host"}
--- PASS: TestGenerateV0 (0.00s)
PASS
ok  	github.com/infobloxopen/atlas-app-toolkit/bloxid	0.663s
```