### PR TITLE
cmode: removed double logging

### DIFF
--- a/cmode/logger/logger.go
+++ b/cmode/logger/logger.go
@@ -26,7 +26,6 @@ func (l *CModeLogger) ParseAndSet(val string) error {
 		return err
 	}
 	l.SetLevel(level)
-	l.Infof("Logging level set to %v", level)
 	return nil
 }
 


### PR DESCRIPTION
CMode already prints about value change. This line created double log entry:

```
INFO[0142] Logging level set to info                    
INFO[0142] loglevel is set to info
```