### PR TITLE
Remove uses of protoc-gen-go/generator

### DIFF
--- a/auth/context.go
+++ b/auth/context.go
@@ -1,10 +1,10 @@
-package util
+package auth
 
 import (
 	"context"
+
 	"google.golang.org/grpc/metadata"
 
-	"github.com/infobloxopen/atlas-app-toolkit/auth"
 	"github.com/infobloxopen/atlas-app-toolkit/gateway"
 	"github.com/infobloxopen/atlas-app-toolkit/requestid"
 )
@@ -12,7 +12,7 @@ import (
 // OutgoingContext set to outgoing context request_id, auth_token, X-Forwarded-For, x-geo- and x-b3- headers value
 func OutgoingContext(ctx context.Context) context.Context {
 	keys := []string{
-		auth.AuthorizationHeader,
+		AuthorizationHeader,
 		requestid.DefaultRequestIDKey,
 		gateway.XForwardedFor,
 	}

--- a/gateway/field_presence.go
+++ b/gateway/field_presence.go
@@ -9,10 +9,11 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/golang/protobuf/protoc-gen-go/generator"
 	"google.golang.org/genproto/protobuf/field_mask"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/infobloxopen/atlas-app-toolkit/util"
 )
 
 const (
@@ -90,7 +91,7 @@ func NewPresenceAnnotator(methods ...string) func(context.Context, *http.Request
 func extendPath(parent []string, key string) []string {
 	newPath := make([]string, len(parent)+1)
 	copy(newPath, parent)
-	newPath[len(newPath)-1] = generator.CamelCase(key)
+	newPath[len(newPath)-1] = util.Camel(key)
 	return newPath
 }
 

--- a/gorm/converter.go
+++ b/gorm/converter.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/protoc-gen-go/generator"
 
 	"github.com/infobloxopen/atlas-app-toolkit/query"
 	"github.com/infobloxopen/atlas-app-toolkit/rpc/resource"
+	"github.com/infobloxopen/atlas-app-toolkit/util"
 )
 
 // DefaultFilteringConditionProcessor processes filter operator conversion
@@ -182,7 +182,7 @@ func (p *DefaultFilteringConditionProcessor) ProcessStringCondition(ctx context.
 	objType := indirectType(reflect.TypeOf(p.pb))
 	pathLength := len(fieldPath)
 	for i, part := range fieldPath {
-		sf, ok := objType.FieldByName(generator.CamelCase(part))
+		sf, ok := objType.FieldByName(util.Camel(part))
 		if !ok {
 			return nil, fmt.Errorf("Cannot find field %s in %s", part, objType)
 		}
@@ -198,7 +198,7 @@ func (p *DefaultFilteringConditionProcessor) ProcessStringCondition(ctx context.
 					return nil, err
 				}
 				newPb := reflect.New(objType)
-				v := newPb.Elem().FieldByName(generator.CamelCase(part))
+				v := newPb.Elem().FieldByName(util.Camel(part))
 				v.Set(reflect.ValueOf(id))
 				toOrm := newPb.MethodByName("ToORM")
 				if !toOrm.IsValid() {
@@ -217,7 +217,7 @@ func (p *DefaultFilteringConditionProcessor) ProcessStringCondition(ctx context.
 						return nil, fmt.Errorf("ToOrm second return value of %s is expected to be error", objType)
 					}
 				}
-				ormId := orm.FieldByName(generator.CamelCase(part))
+				ormId := orm.FieldByName(util.Camel(part))
 				if !ormId.IsValid() {
 					return nil, fmt.Errorf("Cannot find field %s in %s", part, objType)
 				}

--- a/gorm/fields.go
+++ b/gorm/fields.go
@@ -7,10 +7,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/golang/protobuf/protoc-gen-go/generator"
 	"github.com/jinzhu/gorm"
 
 	"github.com/infobloxopen/atlas-app-toolkit/query"
+	"github.com/infobloxopen/atlas-app-toolkit/util"
 )
 
 // DefaultFieldSelectionConverter performs default convertion for FieldSelection collection operator
@@ -76,14 +76,14 @@ fields:
 }
 
 func handlePreloads(f *query.Field, objType reflect.Type) ([]string, error) {
-	sf, ok := objType.FieldByName(generator.CamelCase(f.GetName()))
+	sf, ok := objType.FieldByName(util.Camel(f.GetName()))
 	if !ok {
 		return nil, nil
 	}
 	fType := indirectType(sf.Type)
 	if f.GetSubs() == nil {
 		if isModel(fType) {
-			return []string{generator.CamelCase(f.GetName())}, nil
+			return []string{util.Camel(f.GetName())}, nil
 		} else {
 			return nil, nil
 		}
@@ -100,11 +100,11 @@ func handlePreloads(f *query.Field, objType reflect.Type) ([]string, error) {
 			return nil, err
 		}
 		for i, e := range subPreload {
-			subPreload[i] = generator.CamelCase(f.GetName()) + "." + e
+			subPreload[i] = util.Camel(f.GetName()) + "." + e
 		}
 		toPreload = append(toPreload, subPreload...)
 	}
-	return append(toPreload, generator.CamelCase(f.GetName())), nil
+	return append(toPreload, util.Camel(f.GetName())), nil
 }
 
 func getSortedFieldNames(fields map[string]*query.Field) []string {

--- a/gorm/utilities.go
+++ b/gorm/utilities.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/protoc-gen-go/generator"
 	jgorm "github.com/jinzhu/gorm"
 	"github.com/jinzhu/gorm/dialects/postgres"
 	"github.com/jinzhu/inflection"
@@ -16,6 +15,7 @@ import (
 	"time"
 
 	"github.com/infobloxopen/atlas-app-toolkit/rpc/resource"
+	"github.com/infobloxopen/atlas-app-toolkit/util"
 )
 
 // HandleFieldPath converts fieldPath to appropriate db string for use in where/order by clauses
@@ -36,7 +36,7 @@ func HandleFieldPath(ctx context.Context, fieldPath []string, obj interface{}) (
 		}
 	}
 	if len(fieldPath) == 2 {
-		return dbPath, generator.CamelCase(fieldPath[0]), nil
+		return dbPath, util.Camel(fieldPath[0]), nil
 	}
 	return dbPath, "", nil
 }
@@ -84,7 +84,7 @@ func isRawJSON(values ...string) bool {
 
 //TODO: add supprt for embeded objects
 func IsJSONCondition(ctx context.Context, fieldPath []string, obj interface{}) bool {
-	fieldName := generator.CamelCase(fieldPath[0])
+	fieldName := util.Camel(fieldPath[0])
 	objType := indirectType(reflect.TypeOf(obj))
 	field, ok := objType.FieldByName(fieldName)
 	if !ok {
@@ -108,7 +108,7 @@ func fieldPathToDBName(fieldPath []string, obj interface{}) (string, error) {
 		if !isModel(objType) {
 			return "", fmt.Errorf("%s: non-last field of %s field path should be a model", objType, fieldPath)
 		}
-		sf, ok := objType.FieldByName(generator.CamelCase(part))
+		sf, ok := objType.FieldByName(util.Camel(part))
 		if !ok {
 			return "", fmt.Errorf("Cannot find field %s in %s", part, objType)
 		}

--- a/util/camel.go
+++ b/util/camel.go
@@ -1,0 +1,63 @@
+package util
+
+// Camel returns the CamelCased name.
+//
+// This was moved from the now deprecated github.com/golang/protobuf/protoc-gen-go/generator package
+//
+// If there is an interior underscore followed by a lower case letter,
+// drop the underscore and convert the letter to upper case.
+// There is a remote possibility of this rewrite causing a name collision,
+// but it's so remote we're prepared to pretend it's nonexistent - since the
+// C++ generator lowercases names, it's extremely unlikely to have two fields
+// with different capitalizations.
+// In short, _my_field_name_2 becomes XMyFieldName_2.
+func Camel(s string) string {
+	if s == "" {
+		return ""
+	}
+	t := make([]byte, 0, 32)
+	i := 0
+	if s[0] == '_' {
+		// Need a capital letter; drop the '_'.
+		t = append(t, 'X')
+		i++
+	}
+	// Invariant: if the next letter is lower case, it must be converted
+	// to upper case.
+	// That is, we process a word at a time, where words are marked by _ or
+	// upper case letter. Digits are treated as words.
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c == '_' && i+1 < len(s) && isASCIILower(s[i+1]) {
+			continue // Skip the underscore in s.
+		}
+		if isASCIIDigit(c) {
+			t = append(t, c)
+			continue
+		}
+		// Assume we have a letter now - if not, it's a bogus identifier.
+		// The next word is a sequence of characters that must start upper case.
+		if isASCIILower(c) {
+			c ^= ' ' // Make it a capital letter.
+		}
+		t = append(t, c) // Guaranteed not lower case.
+		// Accept lower case sequence that follows.
+		for i+1 < len(s) && isASCIILower(s[i+1]) {
+			i++
+			t = append(t, s[i])
+		}
+	}
+	return string(t)
+}
+
+// And now lots of helper functions.
+
+// Is c an ASCII lower-case letter?
+func isASCIILower(c byte) bool {
+	return 'a' <= c && c <= 'z'
+}
+
+// Is c an ASCII digit?
+func isASCIIDigit(c byte) bool {
+	return '0' <= c && c <= '9'
+}


### PR DESCRIPTION
 This package was intended to use for internal implementation of `protoc-gen-go` https://github.com/golang/protobuf/issues/1104#issuecomment-619420855
```
WARNING: Package "github.com/golang/protobuf/protoc-gen-go/generator" is deprecated.
	A future release of golang/protobuf will delete this package,
	which has long been excluded from the compatibility promise.
```
Above warning causing problem for onprem/cloud components to format the logs into JSON.  and making hard to use `jq` 