### PR TITLE
Fix concurrent use of UnaryServerInterceptor

### DIFF
--- a/gorm/transaction.go
+++ b/gorm/transaction.go
@@ -180,8 +180,7 @@ func UnaryServerInterceptor(db *gorm.DB) grpc.UnaryServerInterceptor {
 
 func UnaryServerInterceptorTxn(txn *Transaction) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
-		// Deep copy is necessary as the next intercepter invocation
-		// overrides txn being used by the previouse invocation.
+		// Deep copy is necessary as a tansaction should be created per request.
 		txn := &Transaction{parent: txn.parent, afterCommitHook: txn.afterCommitHook}
 		defer func() {
 			// simple panic handler


### PR DESCRIPTION
The PR fixes the issue when multiple requests are interacting with database at the same time and the failure occurs due to the common instance of transaction linked to the interceptor function from outside its body. 

```go
    func UnaryServerInterceptor(db *gorm.DB) grpc.UnaryServerInterceptor {
    	txn := &Transaction{parent: db}
    	return UnaryServerInterceptorTxn(txn)
    }

    func UnaryServerInterceptorTxn(txn *Transaction) grpc.UnaryServerInterceptor {
    	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
    	    // here the same txn instance is being processed on every request	
    	    defer func() {
            ...
```

The interceptor is a closure since PR [#243](https://github.com/infobloxopen/atlas-app-toolkit/pull/243) 

Tested with unit tests and by replacing atlas-app-toolkit in atlas.tagging where the issue emerged after upgrading atlas-app-toolkit  to the latest version (v1.1.0)

