### PR TITLE
[ATLAS-11256] Rearrange lock in Commit/Rollback to eliminate race condition

### DIFF
--- a/gorm/transaction.go
+++ b/gorm/transaction.go
@@ -133,15 +133,15 @@ func (t *Transaction) beginWithContextAndOptions(ctx context.Context, opts *sql.
 // Rollback terminates transaction by calling `*gorm.DB.Rollback()`
 // Reset current transaction and returns an error if any.
 func (t *Transaction) Rollback() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	if t.current == nil {
 		return nil
 	}
 	if reflect.ValueOf(t.current.CommonDB()).IsNil() {
 		return status.Error(codes.Unavailable, "Database connection not available")
 	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	t.current.Rollback()
 	err := t.current.Error
 	t.current = nil
@@ -151,11 +151,12 @@ func (t *Transaction) Rollback() error {
 // Commit finishes transaction by calling `*gorm.DB.Commit()`
 // Reset current transaction and returns an error if any.
 func (t *Transaction) Commit(ctx context.Context) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	if t.current == nil || reflect.ValueOf(t.current.CommonDB()).IsNil() {
 		return nil
 	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
 	t.current.Commit()
 	err := t.current.Error
 	if err == nil {


### PR DESCRIPTION
[ATLAS-11256](https://infoblox.atlassian.net/browse/ATLAS-11256) Race conditions in Commit() and Rollback() (atlas-app-toolkit/gorm/transaction.go)

Tested with existing unit tests and submitted in the ticket _**atlas-commit**_ concurrency test application. 