### PR TITLE
Tracing fixes for error span

### DIFF
--- a/tracing/span.go
+++ b/tracing/span.go
@@ -78,16 +78,15 @@ func AddErrorCurrentSpan(ctx context.Context, err error) error {
 
 //AddErrorSpan adds error into span
 func AddErrorSpan(span *trace.Span, err error) error {
-	var code int32 = trace.StatusCodeUnknown
+	var code int32 = trace.StatusCodeOK
 	status, ok := status.FromError(err)
 	if ok && status != nil {
 		code = int32(status.Code())
 	}
 
-	span.SetStatus(trace.Status{
-		Code:    code,
-		Message: err.Error(),
-	})
+	if code != trace.StatusCodeOK {
+		span.AddAttributes(trace.Int64Attribute("census.status_code", int64(code)), trace.StringAttribute("census.status_description", err.Error()), trace.BoolAttribute("error", true))
+	}
 
 	return err
 }


### PR DESCRIPTION
Fixes for adding error spans caused by bug in open telemetry collector.

See discussion here: https://github.com/open-telemetry/opentelemetry-collector/pull/70
* `code` should be added as a `census.status_code` tag.
* `message` should be added as a `census.status_description` tag.
* If code is NOT StatusCodeOK, then add `error` tag with value `true`
