### PR TITLE
bloxid: added WithRandomEncodedID to transform bloxid unique id to full bloxid

### DIFF
--- a/bloxid/README.md
+++ b/bloxid/README.md
@@ -90,3 +90,16 @@ parsed, err := NewV0("blox0.iam.group.us-com-1.tshwyq3mfkgqqcfa76a5hbr2uaayzw3h"
 // parsed.Decoded(): "9c8f6c436c2a8d0808a0ff81d3863aa0018cdb67"
 ```
 
+create bloxid from unique entity id portion of a previously generated bloxid with random scheme
+```
+v0, err := NewV0("",
+            WithEntityDomain("iam"),
+            WithEntityType("group"),
+            WithRealm("us-com-1"),
+            WithRandomEncodedID("tshwyq3mfkgqqcfa76a5hbr2uaayzw3h"),
+        )
+// v0.String(): blox0.iam.group.us-com-1.tshwyq3mfkgqqcfa76a5hbr2uaayzw3h
+// v0.Encoded(): "tshwyq3mfkgqqcfa76a5hbr2uaayzw3h"
+// v0.Decoded(): "9c8f6c436c2a8d0808a0ff81d3863aa0018cdb67"
+```
+

--- a/bloxid/README.md
+++ b/bloxid/README.md
@@ -32,9 +32,9 @@ v0, err := NewV0("",
             WithEntityDomain("iam"),
             WithEntityType("user"),
             WithRealm("us-com-1"),
-            WithExtrinsic("123456"),
+            WithSchemer(WithExtrinsic("123456")),
         )
-// v0.String(): blox0.iam.user.us-com-1.ivmfiurrgiztinjweaqcaiba
+// v0.String(): "blox0.iam.user.us-com-1.ivmfiurrgiztinjweaqcaiba"
 // v0.Decoded(): "123456"
 ```
 
@@ -53,10 +53,10 @@ v0, err := NewV0("",
             WithEntityDomain("infra"),
             WithEntityType("host"),
             WithRealm("us-com-1"),
-            WithHashIDInt64(1),
+            WithSchemer(WithHashIDInt64(1)),
             WithHashIDSalt("test"),
         )
-// v0.String(): blox0.infra.host.us-com-1.jbeuiwrsmq3tkmzwmuzwcojsmrqwemrtgy3tqzbvhbsdizjvhe2dkn3cgzrdizlb
+// v0.String(): "blox0.infra.host.us-com-1.jbeuiwrsmq3tkmzwmuzwcojsmrqwemrtgy3tqzbvhbsdizjvhe2dkn3cgzrdizlb"
 // v0.HashIDInt64(): 1
 ```
 
@@ -78,7 +78,7 @@ v0, err := NewV0("",
             WithEntityType("group"),
             WithRealm("us-com-1"),
         )
-// v0.String(): blox0.iam.group.us-com-1.tshwyq3mfkgqqcfa76a5hbr2uaayzw3h
+// v0.String(): "blox0.iam.group.us-com-1.tshwyq3mfkgqqcfa76a5hbr2uaayzw3h"
 // v0.Encoded(): "tshwyq3mfkgqqcfa76a5hbr2uaayzw3h"
 // v0.Decoded(): "9c8f6c436c2a8d0808a0ff81d3863aa0018cdb67"
 ```
@@ -96,9 +96,9 @@ v0, err := NewV0("",
             WithEntityDomain("iam"),
             WithEntityType("group"),
             WithRealm("us-com-1"),
-            WithRandomEncodedID("tshwyq3mfkgqqcfa76a5hbr2uaayzw3h"),
+            WithSchemer(WithRandomEncodedID("tshwyq3mfkgqqcfa76a5hbr2uaayzw3h")),
         )
-// v0.String(): blox0.iam.group.us-com-1.tshwyq3mfkgqqcfa76a5hbr2uaayzw3h
+// v0.String(): "blox0.iam.group.us-com-1.tshwyq3mfkgqqcfa76a5hbr2uaayzw3h"
 // v0.Encoded(): "tshwyq3mfkgqqcfa76a5hbr2uaayzw3h"
 // v0.Decoded(): "9c8f6c436c2a8d0808a0ff81d3863aa0018cdb67"
 ```

--- a/bloxid/extrinsicids.go
+++ b/bloxid/extrinsicids.go
@@ -23,9 +23,29 @@ var (
 // WithExtrinsicID supplies a locally unique ID that is not randomly generated
 func WithExtrinsicID(eid string) func(o *V0Options) {
 	return func(o *V0Options) {
-		o.extrinsicID = eid
-		o.scheme = IDSchemeExtrinsic
+		o.schemer = &schemerExtrinsicID{
+			extrinsicID: eid,
+			scheme:      IDSchemeExtrinsic,
+		}
 	}
+}
+
+type schemerExtrinsicID struct {
+	extrinsicID string
+	scheme      string
+}
+
+var _ Schemer = (*schemerRandomEncodedID)(nil)
+
+func (sch *schemerExtrinsicID) FromEntityID(opts *V0Options) (scheme string, decoded string, encoded string, err error) {
+	decoded, err = getExtrinsicID(sch.extrinsicID)
+	if err != nil {
+		return
+	}
+
+	encoded = encodeLowerAlphaNumeric(extrinsicIDPrefix, decoded)
+	scheme = IDSchemeExtrinsic
+	return
 }
 
 func validateGetExtrinsicID(id string) error {

--- a/bloxid/randomids.go
+++ b/bloxid/randomids.go
@@ -27,9 +27,28 @@ var (
 // WithRandomEncodedID supplies the unique id portion of a previously generated random scheme bloxid
 func WithRandomEncodedID(eid string) func(o *V0Options) {
 	return func(o *V0Options) {
-		o.encodedID = eid
-		o.scheme = IDSchemeRandom
+		o.schemer = &schemerRandomEncodedID{
+			encodedID: eid,
+			scheme:    IDSchemeRandom,
+		}
 	}
+}
+
+type schemerRandomEncodedID struct {
+	encodedID string
+	scheme    string
+}
+
+var _ Schemer = (*schemerRandomEncodedID)(nil)
+
+func (sch *schemerRandomEncodedID) FromEntityID(opts *V0Options) (scheme string, decoded string, encoded string, err error) {
+	decoded, err = getDecodedIDFromRandomEncodedID(sch.encodedID)
+	if err != nil {
+		return
+	}
+	encoded = sch.encodedID
+	scheme = IDSchemeRandom
+	return
 }
 
 func validateGetRandomEncodedID(id string) error {

--- a/bloxid/randomids.go
+++ b/bloxid/randomids.go
@@ -1,0 +1,61 @@
+package bloxid
+
+import (
+	"encoding/base32"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	IDSchemeRandom = "random"
+
+	RandomEncodedIDSize = 32
+)
+
+var (
+	ErrEmptyRandomEncodedID           = errors.New("empty random scheme encoded id")
+	ErrInvalidSizeRandomEncodedID     = fmt.Errorf("random scheme encoded id must be %d chars", RandomEncodedIDSize)
+	ErrInvalidAlphabetRandomEncodedID = errors.New("invalid random scheme encoded id")
+	ErrInvalidRandomEncodedID         = errors.New("invalid random scheme encoded id")
+
+	rRandomEncodedIDRegex = regexp.MustCompile(`^[0-9a-z]+$`)
+)
+
+// WithRandomEncodedID supplies the unique id portion of a previously generated random scheme bloxid
+func WithRandomEncodedID(eid string) func(o *V0Options) {
+	return func(o *V0Options) {
+		o.encodedID = eid
+		o.scheme = IDSchemeRandom
+	}
+}
+
+func validateGetRandomEncodedID(id string) error {
+	if ln := len(id); ln < 1 {
+		return ErrEmptyRandomEncodedID
+	} else if ln != RandomEncodedIDSize {
+		return ErrInvalidSizeRandomEncodedID
+	}
+
+	if !rRandomEncodedIDRegex.MatchString(id) {
+		return ErrInvalidAlphabetRandomEncodedID
+	}
+
+	return nil
+}
+
+func getDecodedIDFromRandomEncodedID(id string) (string, error) {
+	if err := validateGetRandomEncodedID(id); err != nil {
+		return "", err
+	}
+
+	val, err := base32.StdEncoding.DecodeString(strings.ToUpper(id))
+	if err != nil {
+		return "", ErrInvalidRandomEncodedID
+	}
+	decoded := hex.EncodeToString(val)
+
+	return decoded, nil
+}

--- a/bloxid/schemer.go
+++ b/bloxid/schemer.go
@@ -1,0 +1,12 @@
+package bloxid
+
+func WithSchemer(fnOpt GenerateV0Opts) func(o *V0Options) {
+	return func(o *V0Options) {
+		fnOpt(o)
+	}
+}
+
+// Schemer defines the interface required for encoding/decoding different schemes
+type Schemer interface {
+	FromEntityID(opts *V0Options) (scheme string, decoded string, encoded string, err error)
+}

--- a/bloxid/utils.go
+++ b/bloxid/utils.go
@@ -1,0 +1,10 @@
+package bloxid
+
+import (
+	"reflect"
+)
+
+// isNilInterface returns whether the interface parameter is nil
+func isNilInterface(i interface{}) bool {
+	return i == nil || reflect.ValueOf(i).IsNil()
+}

--- a/bloxid/v0.go
+++ b/bloxid/v0.go
@@ -14,8 +14,6 @@ const (
 
 	VersionUnknown Version = iota
 	Version0       Version = iota
-
-	IDSchemeRandom = "random"
 )
 
 type Version uint8
@@ -248,6 +246,7 @@ type V0Options struct {
 	extrinsicID  string
 	hashIDInt64  int64
 	hashidSalt   string
+	encodedID    string
 	scheme       string
 }
 
@@ -270,6 +269,14 @@ func WithRealm(realm string) func(o *V0Options) {
 		o.realm = realm
 	}
 }
+
+/* WIP
+func WithScheme(fnOpt GenerateV0Opts) func(o *V0Options) {
+	return func(o *V0Options) {
+		fnOpt(o)
+	}
+}
+*/
 
 func generateV0(opts *V0Options, fnOpts ...GenerateV0Opts) (*V0, error) {
 	for _, fn := range fnOpts {
@@ -320,6 +327,14 @@ func uniqueID(opts *V0Options) (encoded, decoded string, err error) {
 		}
 
 		encoded = encodeLowerAlphaNumeric(extrinsicIDPrefix, decoded)
+
+	case IDSchemeRandom:
+
+		decoded, err = getDecodedIDFromRandomEncodedID(opts.encodedID)
+		if err != nil {
+			return
+		}
+		encoded = opts.encodedID
 
 	default:
 		rndm := randDefault()

--- a/bloxid/v0.go
+++ b/bloxid/v0.go
@@ -243,11 +243,9 @@ type V0Options struct {
 	entityDomain string
 	entityType   string
 	realm        string
-	extrinsicID  string
-	hashIDInt64  int64
 	hashidSalt   string
-	encodedID    string
 	scheme       string
+	schemer      Schemer
 }
 
 type GenerateV0Opts func(o *V0Options)
@@ -270,14 +268,6 @@ func WithRealm(realm string) func(o *V0Options) {
 	}
 }
 
-/* WIP
-func WithScheme(fnOpt GenerateV0Opts) func(o *V0Options) {
-	return func(o *V0Options) {
-		fnOpt(o)
-	}
-}
-*/
-
 func generateV0(opts *V0Options, fnOpts ...GenerateV0Opts) (*V0, error) {
 	for _, fn := range fnOpts {
 		fn(opts)
@@ -288,60 +278,37 @@ func generateV0(opts *V0Options, fnOpts ...GenerateV0Opts) (*V0, error) {
 		return nil, err
 	}
 
-	return &V0{
+	v0 := &V0{
 		version:      Version0,
 		realm:        opts.realm,
 		decoded:      decoded,
 		encoded:      encoded,
 		entityDomain: opts.entityDomain,
 		entityType:   opts.entityType,
-		hashIDInt64:  opts.hashIDInt64,
 		scheme:       opts.scheme,
-	}, nil
+	}
+
+	if !isNilInterface(opts.schemer) {
+		if t, ok := opts.schemer.(*schemerHashIDInt64); ok {
+			v0.hashIDInt64 = t.HashIDInt64
+		}
+	}
+
+	return v0, nil
 }
 
 func uniqueID(opts *V0Options) (encoded, decoded string, err error) {
 
-	switch opts.scheme {
-	case IDSchemeHashID:
-		var hashed string
-
-		if opts.hashIDInt64 < 0 {
-			err = ErrInvalidID
-			return
-		}
-
-		decoded = fmt.Sprintf("%v", opts.hashIDInt64)
-		hashed, err = getHashID(opts.hashIDInt64, opts.hashidSalt)
-		if err != nil {
-			return
-		}
-
-		encoded = encodeLowerAlphaNumeric(hashIDPrefix, hashed)
-
-	case IDSchemeExtrinsic:
-
-		decoded, err = getExtrinsicID(opts.extrinsicID)
-		if err != nil {
-			return
-		}
-
-		encoded = encodeLowerAlphaNumeric(extrinsicIDPrefix, decoded)
-
-	case IDSchemeRandom:
-
-		decoded, err = getDecodedIDFromRandomEncodedID(opts.encodedID)
-		if err != nil {
-			return
-		}
-		encoded = opts.encodedID
-
-	default:
-		rndm := randDefault()
-		decoded = hex.EncodeToString(rndm)
-		encoded = strings.ToLower(base32.StdEncoding.EncodeToString(rndm))
-		opts.scheme = IDSchemeRandom
+	if !isNilInterface(opts.schemer) {
+		opts.scheme, decoded, encoded, err = opts.schemer.FromEntityID(opts)
+		return
 	}
+
+	// default to random scheme to generate the entity id
+	rndm := randDefault()
+	decoded = hex.EncodeToString(rndm)
+	encoded = strings.ToLower(base32.StdEncoding.EncodeToString(rndm))
+	opts.scheme = IDSchemeRandom
 
 	return
 }

--- a/bloxid/v0_test.go
+++ b/bloxid/v0_test.go
@@ -86,7 +86,7 @@ type generateTestCase struct {
 	err          error
 }
 
-func TestGenerateV0(t *testing.T) {
+func TestGenerateV0WithExtrinsicIDDeprecated(t *testing.T) {
 	var testmap = []generateTestCase{
 		{
 			realm:        "us-com-1",
@@ -189,6 +189,126 @@ func TestGenerateV0(t *testing.T) {
 			continue
 		}
 
+		//              t.Log(v0)
+		//              t.Logf("%#v\n", v0)
+		validateGenerateV0(t, tm, v0, err)
+
+		parsed, err := NewV0(v0.String())
+		if err != tm.err {
+			t.Logf("test: %#v", tm)
+			t.Errorf("got: %s wanted: %s", err, tm.err)
+		}
+		if err != nil {
+			continue
+		}
+
+		validateGenerateV0(t, tm, parsed, err)
+	}
+}
+
+func TestGenerateV0WithExtrinsicID(t *testing.T) {
+	var testmap = []generateTestCase{
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			expected:     "blox0.infra.host.us-com-1.",
+			err:          ErrEmptyExtrinsicID,
+		},
+		{
+			realm:        "us-com-2",
+			entityDomain: "infra",
+			entityType:   "host",
+			expected:     "blox0.infra.host.us-com-2.",
+			err:          ErrEmptyExtrinsicID,
+		},
+
+		// ensure `=` is not part of id when encoded
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "1",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurreaqcaiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "12",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiqcaiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "123",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgizsaiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "1234",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztiiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "12345",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztinja",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "123456",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztinjweaqcaiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "1234567",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztinjwg4qcaiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "12345678",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztinjwg44caiba",
+		},
+		{
+			realm:        "us-com-1",
+			entityDomain: "infra",
+			entityType:   "host",
+			extrinsicID:  "123456789",
+			expected:     "blox0.infra.host.us-com-1.ivmfiurrgiztinjwg44dsiba",
+		},
+	}
+
+	for index, tm := range testmap {
+		v0, err := NewV0("",
+			WithEntityDomain(tm.entityDomain),
+			WithEntityType(tm.entityType),
+			WithRealm(tm.realm),
+			WithSchemer(WithExtrinsicID(tm.extrinsicID)),
+		)
+		if err != tm.err {
+			t.Logf("test: %#v", tm)
+			t.Errorf("index: %d got: %s wanted error: %s", index, err, tm.err)
+		}
+		if err != nil {
+			continue
+		}
+
+		if v0 == nil {
+			t.Errorf("unexpected nil id")
+			continue
+		}
+
 		validateGenerateV0(t, tm, v0, err)
 
 		parsed, err := NewV0(v0.String())
@@ -249,7 +369,7 @@ func TestGenerateV0WithRandomEncodedID(t *testing.T) {
 			WithEntityDomain(tm.entityDomain),
 			WithEntityType(tm.entityType),
 			WithRealm(tm.realm),
-			WithRandomEncodedID(tm.encodedID),
+			WithSchemer(WithRandomEncodedID(tm.encodedID)),
 		)
 		if err != tm.err {
 			t.Logf("test: %#v", tm)


### PR DESCRIPTION
### DEMO:
```
~/src/github.com/infobloxopen/atlas-app-toolkit/bloxid
# wlu@rm-ml-wlu: go test -v
...
=== RUN   TestHashIDInttoIntDeprecated
=== RUN   TestHashIDInttoIntDeprecated/Valid_input
=== RUN   TestHashIDInttoIntDeprecated/Negative_number
--- PASS: TestHashIDInttoIntDeprecated (0.00s)
    --- PASS: TestHashIDInttoIntDeprecated/Valid_input (0.00s)
    --- PASS: TestHashIDInttoIntDeprecated/Negative_number (0.00s)
=== RUN   TestHashIDInttoInt
=== RUN   TestHashIDInttoInt/Valid_input
=== RUN   TestHashIDInttoInt/Negative_number
--- PASS: TestHashIDInttoInt (0.00s)
    --- PASS: TestHashIDInttoInt/Valid_input (0.00s)
    --- PASS: TestHashIDInttoInt/Negative_number (0.00s)
...
=== RUN   TestGenerateV0WithExtrinsicIDDeprecated
--- PASS: TestGenerateV0WithExtrinsicIDDeprecated (0.00s)
=== RUN   TestGenerateV0WithExtrinsicID
--- PASS: TestGenerateV0WithExtrinsicID (0.00s)
=== RUN   TestGenerateV0WithRandomEncodedID
--- PASS: TestGenerateV0WithRandomEncodedID (0.00s)
=== RUN   TestGenerateV0RandomEntityID
    v0_test.go:445: created random scheme bloxid: blox0.iam.group.us-com-1.mb77dnuidm75moy53fxgbvys7riobdkp
--- PASS: TestGenerateV0RandomEntityID (0.00s)
PASS
ok  	github.com/infobloxopen/atlas-app-toolkit/bloxid	0.656s
```