### PR TITLE
Render numbers read from JWTs as integers

### DIFF
--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -50,9 +50,9 @@ func GetJWTFieldWithTokenType(ctx context.Context, tokenType, tokenField string,
 	if !ok {
 		return "", errMissingField
 	}
-	switch jwtField.(type) {
+	switch jwtField := jwtField.(type) {
 	case float64:
-		return strconv.FormatFloat(jwtField.(float64), 'f', -1, 64), nil
+		return strconv.FormatFloat(jwtField, 'f', -1, 64), nil
 	default:
 		return fmt.Sprint(jwtField), nil
 	}

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/grpc-ecosystem/go-grpc-middleware/auth"
@@ -49,7 +50,12 @@ func GetJWTFieldWithTokenType(ctx context.Context, tokenType, tokenField string,
 	if !ok {
 		return "", errMissingField
 	}
-	return fmt.Sprint(jwtField), nil
+	switch jwtField.(type) {
+	case float64:
+		return strconv.FormatFloat(jwtField.(float64), 'f', -1, 64), nil
+	default:
+		return fmt.Sprint(jwtField), nil
+	}
 }
 
 // GetJWTField gets the JWT from a context and returns the specified field

--- a/auth/jwt_test.go
+++ b/auth/jwt_test.go
@@ -99,6 +99,12 @@ func TestGetJWTField(t *testing.T) {
 			expected: "",
 			err:      errMissingField,
 		},
+		{
+			claims:   jwt.MapClaims{"long-id": float64(123456789)},
+			field:    "long-id",
+			expected: "123456789",
+			err:      nil,
+		},
 	}
 	for _, test := range jwtFieldTests {
 		ctx := contextWithToken(


### PR DESCRIPTION
Currently, if there is a long JWT field, e.g. `"ID":"123456789"`, this function will parse and return it as `1.23456789E8`, because all JWT numbers are treated as float64s. This could still be wonky if there are _really_ big numbers in the JWT field, since they'll now render with lots of zeros, but this is probably better for the majority of cases.