### PR TITLE
Added comas in docs

### DIFF
--- a/query/README.md
+++ b/query/README.md
@@ -113,15 +113,15 @@ The syntax of REST representation of `infoblox.api.Sorting` is the following.
 
 The syntax of REST representation of `infoblox.api.Pagination` and `infoblox.api.PageInfo` is the following.
 
-| Paging Mode            | Request Parameters | Response Parameters | Description                                                  |
-| ---------------------- |--------------------|---------------------|--------------------------------------------------------------|
-| Client-driven paging   | _offset            |                     | The integer index (zero-origin) of the offset into a collection of resources. If omitted or null the value is assumed to be “0”. |
-|                        | _limit             |                     | The integer number of resources to be returned in the response. The service may impose maximum value. If omitted the service may impose a default value. |
-|                        |                    | _offset             | The service may optionally* include the offset of the next page of resources. A null value indicates no more pages. |
-|                        |                    | _size               | The service may optionally include the total number of resources being paged. |
-| Server-driven paging   | _page_token        |                     | The service-defined string used to identify a page of resources. A null value indicates the first page. |
-|                        |                    | _page_token         | The service response should contain a string to indicate the next page of resources. A null value indicates no more pages. |
-|                        |                    | _size               | The service may optionally include the total number of resources being paged. |
+| Paging Mode            | Request Parameters | Response Parameters | Description                                                                                                                                               |
+| ---------------------- |--------------------|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Client-driven paging   | _offset            |                     | The integer index (zero-origin) of the offset into a collection of resources. If omitted or null, the value is assumed to be “0”.                         |
+|                        | _limit             |                     | The integer number of resources to be returned in the response. The service may impose maximum value. If omitted, the service may impose a default value. |
+|                        |                    | _offset             | The service may optionally* include the offset of the next page of resources. A null value indicates no more pages.                                       |
+|                        |                    | _size               | The service may optionally include the total number of resources being paged.                                                                             |
+| Server-driven paging   | _page_token        |                     | The service-defined string used to identify a page of resources. A null value indicates the first page.                                                   |
+|                        |                    | _page_token         | The service response should contain a string to indicate the next page of resources. A null value indicates no more pages.                                |
+|                        |                    | _size               | The service may optionally include the total number of resources being paged.                                                                             |
 
 ## Field Selection
 

--- a/query/collection_operators.pb.go
+++ b/query/collection_operators.pb.go
@@ -1295,11 +1295,11 @@ type Pagination struct {
 	// A null value indicates the first page.
 	PageToken string `protobuf:"bytes,1,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
 	// The integer index of the offset into a collection of resources.
-	// If omitted or null the value is assumed to be "0".
+	// If omitted or null, the value is assumed to be "0".
 	Offset int32 `protobuf:"varint,2,opt,name=offset,proto3" json:"offset,omitempty"`
 	// The integer number of resources to be returned in the response.
 	// The service may impose maximum value.
-	// If omitted the service may impose a default value.
+	// If omitted, the service may impose a default value.
 	Limit int32 `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`
 }
 

--- a/query/collection_operators.proto
+++ b/query/collection_operators.proto
@@ -196,11 +196,11 @@ message Pagination {
     // A null value indicates the first page.
     string page_token = 1;
     // The integer index of the offset into a collection of resources.
-    // If omitted or null the value is assumed to be "0".
+    // If omitted or null, the value is assumed to be "0".
     int32 offset = 2;
     // The integer number of resources to be returned in the response.
     // The service may impose maximum value.
-    // If omitted the service may impose a default value.
+    // If omitted, the service may impose a default value.
     int32 limit = 3;
 }
 


### PR DESCRIPTION
While being in a process of reviewing new API our reviewer suggested adding a few comas for clarity.