### PR TITLE
Cherry pick fix for panic `reflect.Value.Interface on zero value`

### DIFF
--- a/gorm/converter.go
+++ b/gorm/converter.go
@@ -175,6 +175,12 @@ func (converter *DefaultFilteringConditionConverter) StringConditionToGorm(ctx c
 		return converter.insensitiveCaseStringConditionToGorm(neg, dbName, o), []interface{}{value}, assocToJoin, nil
 	}
 
+	// N.B. if the user specifies a value that the codec translates to NULL
+	// (e.g. `field1 == ""` for string columns) instead of using the explicit
+	// support for identity (`field1 == null`), the results of this syntax may
+	// not match user expectations - `(col_name = NULL)` will match no rows,
+	// not even rows with NULL values. Did the user intend to match rows with
+	// NULL values (`field1 IS NULL`)?
 	return fmt.Sprintf("%s(%s %s ?)", neg, dbName, o), []interface{}{value}, assocToJoin, nil
 }
 
@@ -225,6 +231,14 @@ func (p *DefaultFilteringConditionProcessor) ProcessStringCondition(ctx context.
 				ormId := orm.FieldByName(generator.CamelCase(part))
 				if !ormId.IsValid() {
 					return nil, fmt.Errorf("Cannot find field %s in %s", part, objType)
+				}
+				// For type values where the codec translates a NULL value in
+				// SQL, we receive a pointer of nil value. E.g. `""`.
+				switch ormId.Kind() {
+				case reflect.Ptr, reflect.UnsafePointer:
+					if ormId.IsNil() {
+						return nil, nil
+					}
 				}
 				return reflect.Indirect(ormId).Interface(), nil
 


### PR DESCRIPTION
This PR is a cherry-pick of PR #396 to the `v0.25` branch:

```
git checkout tags/v0.25.4
git checkout -b cherry_pick_filter_nil
git cherry-pick 7670b4b57984186272ab7039733dff3da333b5fd
```

There were no conflicts to resolve.