### PR TITLE
promoting changes to add support for read only db instance

### DIFF
--- a/gorm/transaction.go
+++ b/gorm/transaction.go
@@ -72,7 +72,7 @@ type DatabaseOption func(*databaseOptions)
 // WithRODB returns closure to set the readOnlyReplica flag
 func WithRODB(readOnlyReplica bool) DatabaseOption {
 	return func(ops *databaseOptions) {
-		if readOnlyReplica == false {
+		if !readOnlyReplica {
 			ops.database = dbReadWrite
 		} else {
 			ops.database = dbReadOnly
@@ -115,7 +115,7 @@ func getReadOnlyDBTxn(ctx context.Context, opts *databaseOptions, txn *Transacti
 	case opts.txOpts != nil:
 		// We should error in two cases 1. We should error if read-only DB requested with read-write txn
 		// 2. If no txn options provided in previous call but provided in subsequent call
-		if opts.txOpts.ReadOnly == false || txn.currentOpts.database != dbNotSet {
+		if !opts.txOpts.ReadOnly || txn.currentOpts.database != dbNotSet {
 			return nil, ErrCtxTxnOptMismatch
 		}
 		txnOpts := *opts.txOpts

--- a/gorm/transaction.go
+++ b/gorm/transaction.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/infobloxopen/atlas-app-toolkit/rpc/errdetails"
 	"github.com/jinzhu/gorm"
-	logger "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -19,24 +18,25 @@ import (
 // This prevents collisions with keys defined in other packages.
 type ctxKey int
 
-// readOnlyDBKey is an unexported type and used to define a key for storing read only db instance in the context.
-// This prevents collisions with keys defined in other package
-type readOnlyDBKey int
+// This is used to define various options to set/get the current database setup in the context
+type dbType int
 
 // txnKey is the key for `*Transaction` values in `context.Context`.
 // It is unexported; clients use NewContext and FromContext
 // instead of using this key directly.
 var txnKey ctxKey
 
-// roDBKey is the key used for storing read-only db instance in the context.
-// It is unexported; clients use BeginFromContext with options to get the read only db instance
-// instead of using this key directly.
-var roDBKey readOnlyDBKey
-
 var (
-	ErrCtxTxnMissing = errors.New("Database transaction for request missing in context")
-	ErrCtxTxnNoDB    = errors.New("Transaction in context, but DB is nil")
-	ErrNoReadOnlyDB  = errors.New("No read-only DB")
+	ErrCtxTxnMissing     = errors.New("Database transaction for request missing in context")
+	ErrCtxTxnNoDB        = errors.New("Transaction in context, but DB is nil")
+	ErrCtxTxnOptMismatch = errors.New("Transaction in context, but Txn opts are mismatched")
+	ErrCtxDBOptMismatch  = errors.New("Transaction in context, but DB opts are mismatched")
+)
+
+const (
+	dbNotSet dbType = iota
+	dbReadOnly
+	dbReadWrite
 )
 
 // NewContext returns a new Context that carries value txn.
@@ -56,24 +56,33 @@ func FromContext(ctx context.Context) (txn *Transaction, ok bool) {
 type Transaction struct {
 	mu              sync.Mutex
 	parent          *gorm.DB
+	parentRO        *gorm.DB
 	current         *gorm.DB
-	readOnly        bool
+	txOpts          *sql.TxOptions
+	currentDB       dbType
 	afterCommitHook []func(context.Context)
 }
 
 type databaseOptions struct {
 	readOnlyReplica bool
+	txOpts          *sql.TxOptions
 }
 
 type DatabaseOption func(*databaseOptions)
 
-// WithRODB returns clouser to set the readOnlyReplica flag
+// WithRODB returns closure to set the readOnlyReplica flag
 func WithRODB(readOnlyReplica bool) DatabaseOption {
 	return func(ops *databaseOptions) {
 		ops.readOnlyReplica = readOnlyReplica
 	}
 }
 
+// WithTxOptions returns a closure to set the TxOptions
+func WithTxOptions(opts *sql.TxOptions) DatabaseOption {
+	return func(ops *databaseOptions) {
+		ops.txOpts = opts
+	}
+}
 func toDatabaseOptions(options ...DatabaseOption) *databaseOptions {
 	opts := &databaseOptions{}
 	for _, op := range options {
@@ -90,30 +99,86 @@ func (t *Transaction) AddAfterCommitHook(hooks ...func(context.Context)) {
 	t.afterCommitHook = append(t.afterCommitHook, hooks...)
 }
 
-// getReadOnlyDBInstance returns the read only database instance stored in the ctx
-func getReadOnlyDBInstance(ctx context.Context) (*gorm.DB, error) {
-	txn, ok := FromContext(ctx)
-	if !ok {
-		return nil, ErrCtxTxnMissing
-	}
-	dbRO, ok := ctx.Value(roDBKey).(*gorm.DB)
-	if !ok {
-		logger.Warnf("BeginFromContext: requested: read-only DB, returns: read-write DB, reason: read-only DB not available")
-		if txn.parent == nil {
-			return nil, ErrCtxTxnNoDB
+// getReadOnlyDBInstance returns the read only db txn if RO DB available otherwise it returns read/write db txn
+func getReadOnlyDBTxn(ctx context.Context, opts *databaseOptions, txn *Transaction) (*gorm.DB, error) {
+	var db *gorm.DB
+	if txn.parentRO == nil {
+		return getReadWriteDBTxn(ctx, opts, txn)
+	} else {
+		if opts.txOpts != nil || txn.txOpts != nil {
+			if opts.txOpts == nil {
+				return nil, ErrCtxTxnOptMismatch
+			} else if txn.txOpts == nil {
+				if opts.txOpts.ReadOnly == false { // For Read Only DB, the Txn should be set as read only before calling this method
+					return nil, ErrCtxTxnOptMismatch
+				}
+				txn.txOpts = &sql.TxOptions{}
+				txn.txOpts.ReadOnly = opts.txOpts.ReadOnly
+				txn.txOpts.Isolation = opts.txOpts.Isolation
+			} else {
+				if opts.txOpts.Isolation != txn.txOpts.Isolation || opts.txOpts.ReadOnly != txn.txOpts.ReadOnly {
+					return nil, ErrCtxTxnOptMismatch
+				}
+			}
+			if txn.current != nil {
+				return txn.current, nil
+			}
+			db = txn.beginReadOnlyWithContextAndOptions(ctx, txn.txOpts)
+		} else {
+			if txn.current != nil {
+				return txn.current, nil
+			}
+			db = txn.beginReadOnlyWithContext(ctx)
 		}
-		db := txn.beginWithContext(ctx)
 		if db.Error != nil {
 			return nil, db.Error
 		}
+		if txn.currentDB == dbNotSet {
+			txn.currentDB = dbReadOnly
+		}
 		return db, nil
 	}
-	txn.readOnly = true
-	return dbRO, nil
 }
 
-// BeginFromContext will return read only db instance if readOnlyReplica flag is set otherwise it will extract transaction wrapper from context and start new transaction
-// If readOnlyReplica flag is set and a txn with read-write db is already in use then it will return a txn from ctx rather than providing a read-only db instance.
+// getReadWriteDBTxn returns the read/write db txn
+func getReadWriteDBTxn(ctx context.Context, opts *databaseOptions, txn *Transaction) (*gorm.DB, error) {
+	var db *gorm.DB
+	if txn.parent == nil {
+		return nil, ErrCtxTxnNoDB
+	}
+	if opts.txOpts != nil || txn.txOpts != nil {
+		if opts.txOpts == nil {
+			return nil, ErrCtxTxnOptMismatch
+		} else if txn.txOpts == nil {
+			txn.txOpts = &sql.TxOptions{}
+			txn.txOpts.Isolation = opts.txOpts.Isolation
+			txn.txOpts.ReadOnly = opts.txOpts.ReadOnly
+		} else {
+			if opts.txOpts.Isolation != txn.txOpts.Isolation || opts.txOpts.ReadOnly != txn.txOpts.ReadOnly {
+				return nil, ErrCtxTxnOptMismatch
+			}
+		}
+		if txn.current != nil {
+			return txn.current, nil
+		}
+		db = txn.beginWithContextAndOptions(ctx, txn.txOpts)
+	} else {
+		if txn.current != nil {
+			return txn.current, nil
+		}
+		db = txn.beginWithContext(ctx)
+	}
+	if db.Error != nil {
+		return nil, db.Error
+	}
+	if txn.currentDB == dbNotSet {
+		txn.currentDB = dbReadWrite
+	}
+	return db, nil
+}
+
+// BeginFromContext will return read only db txn if readOnlyReplica flag is set otherwise it will extract transaction wrapper from context and start new transaction
+// If readOnlyReplica flag is set and read only db is not available then it will check if a txn with read-write db is already in use then it will return a txn from ctx otherwise it will start a new txn with read/write db and return
 // As result new instance of `*gorm.DB` will be returned.
 // Error will be returned in case either transaction or db connection info is missing in context.
 // Gorm specific error can be checked by `*gorm.DB.Error`.
@@ -124,24 +189,15 @@ func BeginFromContext(ctx context.Context, options ...DatabaseOption) (*gorm.DB,
 	}
 	opts := toDatabaseOptions(options...)
 	if opts.readOnlyReplica == true {
-		if txn.current == nil {
-			return getReadOnlyDBInstance(ctx)
+		if txn.currentDB == dbReadWrite && txn.parentRO != nil { //check if currentDB is set to read/write DB in case the RO DB is not available
+			return nil, ErrCtxDBOptMismatch
 		} else {
-			logger.Warnf("BeginFromContext: requested: read-only DB, returns: read-write DB, reason: read-write DB txn in use")
-			return txn.current, nil
+			return getReadOnlyDBTxn(ctx, opts, txn)
 		}
-	} else if txn.readOnly == true {
-		logger.Warnf("BeginFromContext: requested: read-write DB, returns: read-only DB, reason: txn set to read only")
-		return getReadOnlyDBInstance(ctx)
+	} else if txn.currentDB == dbReadOnly {
+		return nil, ErrCtxDBOptMismatch
 	}
-	if txn.parent == nil {
-		return nil, ErrCtxTxnNoDB
-	}
-	db := txn.beginWithContext(ctx)
-	if db.Error != nil {
-		return nil, db.Error
-	}
-	return db, nil
+	return getReadWriteDBTxn(ctx, opts, txn)
 }
 
 // BeginWithOptionsFromContext will extract transaction wrapper from context and start new transaction,
@@ -181,10 +237,32 @@ func (t *Transaction) beginWithContext(ctx context.Context) *gorm.DB {
 	return t.current
 }
 
+func (t *Transaction) beginReadOnlyWithContext(ctx context.Context) *gorm.DB {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.current == nil {
+		t.current = t.parentRO.BeginTx(ctx, nil)
+	}
+
+	return t.current
+}
+
 // BeginWithOptions starts new transaction by calling `*gorm.DB.BeginTx()`
 // Returns new instance of `*gorm.DB` (error can be checked by `*gorm.DB.Error`)
 func (t *Transaction) BeginWithOptions(opts *sql.TxOptions) *gorm.DB {
 	return t.beginWithContextAndOptions(context.Background(), opts)
+}
+
+func (t *Transaction) beginReadOnlyWithContextAndOptions(ctx context.Context, opts *sql.TxOptions) *gorm.DB {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.current == nil {
+		t.current = t.parentRO.BeginTx(ctx, opts)
+	}
+
+	return t.current
 }
 
 func (t *Transaction) beginWithContextAndOptions(ctx context.Context, opts *sql.TxOptions) *gorm.DB {
@@ -243,13 +321,19 @@ func (t *Transaction) Commit(ctx context.Context) error {
 // is aborted, otherwise committed.
 func UnaryServerInterceptor(db *gorm.DB, readOnlyDB ...*gorm.DB) grpc.UnaryServerInterceptor {
 	txn := &Transaction{parent: db}
-	return UnaryServerInterceptorTxn(txn, readOnlyDB...)
+	if len(readOnlyDB) > 0 {
+		dbRO := readOnlyDB[0]
+		if dbRO != nil {
+			txn.parentRO = dbRO
+		}
+	}
+	return UnaryServerInterceptorTxn(txn)
 }
 
-func UnaryServerInterceptorTxn(txn *Transaction, readOnlyDB ...*gorm.DB) grpc.UnaryServerInterceptor {
+func UnaryServerInterceptorTxn(txn *Transaction) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
 		// Deep copy is necessary as a tansaction should be created per request.
-		txn := &Transaction{parent: txn.parent, afterCommitHook: txn.afterCommitHook}
+		txn := &Transaction{parent: txn.parent, parentRO: txn.parentRO, afterCommitHook: txn.afterCommitHook}
 		defer func() {
 			// simple panic handler
 			if perr := recover(); perr != nil {
@@ -288,12 +372,6 @@ func UnaryServerInterceptorTxn(txn *Transaction, readOnlyDB ...*gorm.DB) grpc.Un
 		}()
 
 		ctx = NewContext(ctx, txn)
-		if len(readOnlyDB) > 0 {
-			dbRO := readOnlyDB[0]
-			if dbRO != nil {
-				ctx = context.WithValue(ctx, roDBKey, dbRO)
-			}
-		}
 		resp, err = handler(ctx, req)
 
 		return resp, err

--- a/gorm/transaction_test.go
+++ b/gorm/transaction_test.go
@@ -45,6 +45,98 @@ func TestUnaryServerInterceptor_success(t *testing.T) {
 	}
 }
 
+func TestUnaryServerInterceptor_with_readonlydb(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock - %s", err)
+	}
+	dbReadOnly, dbROMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock - %s", err)
+	}
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+	dbROMock.ExpectBegin()
+
+	gdb, err := gorm.Open("postgres", db)
+	if err != nil {
+		t.Fatalf("failed to open gorm db - %s", err)
+	}
+	dbRO, err := gorm.Open("postgres", dbReadOnly)
+	if err != nil {
+		t.Fatalf("failed to open gorm db - %s", err)
+	}
+
+	interceptor := UnaryServerInterceptor(gdb, dbRO)
+	_, err = interceptor(context.Background(), nil, nil, func(ctx context.Context, req interface{}) (interface{}, error) {
+		txn, ok := FromContext(ctx)
+		if !ok {
+			t.Error("failed to extract transaction from context")
+		}
+		readOnlyDB, err := BeginFromContext(ctx, WithRODB(true))
+		if err != nil {
+			t.Errorf("failed to get read only db instance - %s", err)
+		}
+		if dbRO != readOnlyDB {
+			t.Errorf("failed to set read only db instance")
+		}
+		return nil, txn.Begin().Error
+	})
+	if err != nil {
+		t.Errorf("unexpected error - %s", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("failed to manage transaction on success response - %s", err)
+	}
+}
+
+func TestUnaryServerInterceptorTxn_with_readonlydb(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock - %s", err)
+	}
+	dbReadOnly, dbROMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock - %s", err)
+	}
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+	dbROMock.ExpectBegin()
+
+	gdb, err := gorm.Open("postgres", db)
+	if err != nil {
+		t.Fatalf("failed to open gorm db - %s", err)
+	}
+	dbRO, err := gorm.Open("postgres", dbReadOnly)
+	if err != nil {
+		t.Fatalf("failed to open gorm db - %s", err)
+	}
+	txn := NewTransaction(gdb)
+	interceptor := UnaryServerInterceptorTxn(&txn, dbRO)
+	_, err = interceptor(context.Background(), nil, nil, func(ctx context.Context, req interface{}) (interface{}, error) {
+		txn, ok := FromContext(ctx)
+		if !ok {
+			t.Error("failed to extract transaction from context")
+		}
+		readOnlyDB, err := BeginFromContext(ctx, WithRODB(true))
+		if err != nil {
+			t.Errorf("failed to get read only db instance - %s", err)
+		}
+		if dbRO != readOnlyDB {
+			t.Errorf("failed to set read only db instance")
+		}
+		return nil, txn.Begin().Error
+	})
+	if err != nil {
+		t.Errorf("unexpected error - %s", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("failed to manage transaction on success response - %s", err)
+	}
+}
+
 func TestUnaryServerInterceptorTxn_success(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/gorm/transaction_test.go
+++ b/gorm/transaction_test.go
@@ -14,6 +14,14 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+type dbOptions int
+
+const (
+	noOptions dbOptions = 0
+	readOnly  dbOptions = 1
+	readWrite dbOptions = 2
+)
+
 func TestUnaryServerInterceptor_success(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -50,7 +58,7 @@ func TestUnaryServerInterceptor_with_readonlydb(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create sqlmock - %s", err)
 	}
-	dbReadOnly, dbROMock, err := sqlmock.New()
+	readOnlyDB, dbROMock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("failed to create sqlmock - %s", err)
 	}
@@ -62,7 +70,7 @@ func TestUnaryServerInterceptor_with_readonlydb(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open gorm db - %s", err)
 	}
-	dbRO, err := gorm.Open("postgres", dbReadOnly)
+	dbRO, err := gorm.Open("postgres", readOnlyDB)
 	if err != nil {
 		t.Fatalf("failed to open gorm db - %s", err)
 	}
@@ -73,11 +81,7 @@ func TestUnaryServerInterceptor_with_readonlydb(t *testing.T) {
 		if !ok {
 			t.Error("failed to extract transaction from context")
 		}
-		readOnlyDB, err := BeginFromContext(ctx, WithRODB(true))
-		if err != nil {
-			t.Errorf("failed to get read only db instance - %s", err)
-		}
-		if dbRO != readOnlyDB {
+		if dbRO != txn.parentRO {
 			t.Errorf("failed to set read only db instance")
 		}
 		return nil, txn.Begin().Error
@@ -96,7 +100,7 @@ func TestUnaryServerInterceptorTxn_with_readonlydb(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create sqlmock - %s", err)
 	}
-	dbReadOnly, dbROMock, err := sqlmock.New()
+	readOnlyDB, dbROMock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("failed to create sqlmock - %s", err)
 	}
@@ -108,22 +112,19 @@ func TestUnaryServerInterceptorTxn_with_readonlydb(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open gorm db - %s", err)
 	}
-	dbRO, err := gorm.Open("postgres", dbReadOnly)
+	dbRO, err := gorm.Open("postgres", readOnlyDB)
 	if err != nil {
 		t.Fatalf("failed to open gorm db - %s", err)
 	}
 	txn := NewTransaction(gdb)
-	interceptor := UnaryServerInterceptorTxn(&txn, dbRO)
+	txn.parentRO = dbRO
+	interceptor := UnaryServerInterceptorTxn(&txn)
 	_, err = interceptor(context.Background(), nil, nil, func(ctx context.Context, req interface{}) (interface{}, error) {
 		txn, ok := FromContext(ctx)
 		if !ok {
 			t.Error("failed to extract transaction from context")
 		}
-		readOnlyDB, err := BeginFromContext(ctx, WithRODB(true))
-		if err != nil {
-			t.Errorf("failed to get read only db instance - %s", err)
-		}
-		if dbRO != readOnlyDB {
+		if dbRO != txn.parentRO {
 			t.Errorf("failed to set read only db instance")
 		}
 		return nil, txn.Begin().Error
@@ -421,28 +422,41 @@ func TestContext(t *testing.T) {
 	}
 }
 
-func beginFromContextWithOptions(ctx context.Context, withOpts bool) (*gorm.DB, error) {
+func beginFromContextWithOptions(ctx context.Context, withOpts dbOptions, txOpts *sql.TxOptions) (*gorm.DB, error) {
 	switch withOpts {
-	case true:
-		return BeginFromContext(ctx, WithRODB(true))
-	case false:
-		return BeginFromContext(ctx)
+	case noOptions:
+		if txOpts == nil {
+			return BeginFromContext(ctx)
+		}
+		return BeginFromContext(ctx, WithTxOptions(txOpts))
+	case readOnly:
+		if txOpts == nil {
+			return BeginFromContext(ctx, WithRODB(true))
+		}
+		return BeginFromContext(ctx, WithRODB(true), WithTxOptions(txOpts))
+	case readWrite:
+		if txOpts == nil {
+			return BeginFromContext(ctx, WithRODB(false))
+		}
+		return BeginFromContext(ctx, WithRODB(false), WithTxOptions(txOpts))
 	}
 	return nil, nil
 }
 
-func TestBeginFromContextWithOptions(t *testing.T) {
+func TestBeginFromContextStartWithNoOptions(t *testing.T) {
 	tests := []struct {
 		desc     string
-		withOpts bool
+		withOpts dbOptions
+		txOpts   *sql.TxOptions
 	}{
 		{
-			desc:     "begin without options",
-			withOpts: false,
+			desc:     "begin without options and without Tx options",
+			withOpts: noOptions,
 		},
 		{
-			desc:     "begin with options",
-			withOpts: true,
+			desc:     "begin without options and with Tx options",
+			withOpts: noOptions,
+			txOpts:   &sql.TxOptions{},
 		},
 	}
 	for _, test := range tests {
@@ -468,23 +482,299 @@ func TestBeginFromContextWithOptions(t *testing.T) {
 			}
 			mock.ExpectBegin()
 			dbROMock.ExpectBegin()
-			ctxtxn := &Transaction{parent: gdb}
+			ctxtxn := &Transaction{parent: gdb, parentRO: dbRO}
 			ctx = NewContext(ctx, ctxtxn)
-			ctx = context.WithValue(ctx, roDBKey, dbRO)
-			txn1, err := beginFromContextWithOptions(ctx, test.withOpts)
-			if txn1 == nil {
-				t.Error("Did not receive a transaction from context")
+			if test.txOpts == nil {
+				txn1, err := beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err != nil {
+					t.Error("Received an error beginning transaction")
+				}
+				if txn1 == nil {
+					t.Error("Did not receive a transaction from context")
+				}
+				test.withOpts = readOnly
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error DBOptionsMismatch")
+				}
+				test.withOpts = readWrite
+				txn3, err := beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err != nil {
+					t.Error("Received an error beginning transaction")
+				}
+				if txn3 == nil {
+					t.Error("Did not receive a transaction from context")
+				}
+				// Case: Transaction begin is idempotent
+				if txn1 != txn3 {
+					t.Error("Got a different txn than was opened before")
+				}
+			} else {
+				txn1, err := beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err != nil {
+					t.Error("Received an error beginning transaction")
+				}
+				if txn1 == nil {
+					t.Error("Did not receive a transaction from context")
+				}
+				test.txOpts.ReadOnly = true
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error TxOptionsMismatch")
+				}
+				test.txOpts.ReadOnly = false
+				test.txOpts.Isolation = sql.LevelSerializable
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error TxOptionsMismatch")
+				}
+				test.txOpts.Isolation = sql.LevelDefault
+				test.withOpts = readOnly
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error DBOptionsMismatch")
+				}
+				test.withOpts = readWrite
+				txn3, err := beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err != nil {
+					t.Error("Received an error beginning transaction")
+				}
+				if txn3 == nil {
+					t.Error("Did not receive a transaction from context")
+				}
+				// Case: Transaction begin is idempotent
+				if txn1 != txn3 {
+					t.Error("Got a different txn than was opened before")
+				}
+				test.txOpts.ReadOnly = true
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error TxOptionsMismatch")
+				}
+				test.txOpts.ReadOnly = false
+				test.txOpts.Isolation = sql.LevelSerializable
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error TxOptionsMismatch")
+				}
 			}
+		})
+	}
+}
+
+func TestBeginFromContextStartWithReadOnlyOptions(t *testing.T) {
+	tests := []struct {
+		desc     string
+		withOpts dbOptions
+		txOpts   *sql.TxOptions
+	}{
+		{
+			desc:     "begin with read only options and without Tx options",
+			withOpts: readOnly,
+		},
+		{
+			desc:     "begin with read only options and with Tx options",
+			withOpts: readOnly,
+			txOpts:   &sql.TxOptions{},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+
+			db, mock, err := sqlmock.New()
 			if err != nil {
-				t.Error("Received an error beginning transaction")
+				t.Fatalf("failed to create sqlmock - %s", err)
 			}
-			// Case: Transaction begin is idempotent
-			txn2, err := beginFromContextWithOptions(ctx, !test.withOpts)
-			if txn2 != txn1 {
-				t.Error("Got a different txn than was opened before")
-			}
+			gdb, err := gorm.Open("postgres", db)
 			if err != nil {
-				t.Error("Received an error opening transaction")
+				t.Fatalf("failed to open gorm db - %s", err)
+			}
+			dbReadOnly, dbROMock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("failed to create sqlmock - %s", err)
+			}
+			dbRO, err := gorm.Open("postgres", dbReadOnly)
+			if err != nil {
+				t.Fatalf("failed to open gorm read only db - %s", err)
+			}
+			mock.ExpectBegin()
+			dbROMock.ExpectBegin()
+			ctxtxn := &Transaction{parent: gdb, parentRO: dbRO}
+			ctx = NewContext(ctx, ctxtxn)
+			if test.txOpts == nil {
+				txn1, err := beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err != nil {
+					t.Error("Received an error beginning transaction")
+				}
+				if txn1 == nil {
+					t.Error("Did not receive a transaction from context")
+				}
+				test.withOpts = noOptions
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error DBOptionsMismatch")
+				}
+				test.withOpts = readWrite
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error DBOptionsMismatch")
+				}
+			} else {
+				_, err := beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error TxOptionsMismatch")
+				}
+				test.txOpts.ReadOnly = true
+				txn1, err := beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err != nil {
+					t.Error("Received an error beginning transaction")
+				}
+				if txn1 == nil {
+					t.Error("Did not receive a transaction from context")
+				}
+				test.txOpts.ReadOnly = false
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error TxOptionsMismatch")
+				}
+				test.txOpts.ReadOnly = true
+				test.txOpts.Isolation = sql.LevelSerializable
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error TxOptionsMismatch")
+				}
+				test.txOpts.Isolation = sql.LevelDefault
+				test.withOpts = noOptions
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error DBOptionsMismatch")
+				}
+				test.withOpts = readWrite
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error DBOptionsMismatch")
+				}
+			}
+		})
+	}
+}
+
+func TestBeginFromContextStartWithReadWriteOptions(t *testing.T) {
+	tests := []struct {
+		desc     string
+		withOpts dbOptions
+		txOpts   *sql.TxOptions
+	}{
+		{
+			desc:     "begin with read write options and without Tx options",
+			withOpts: readWrite,
+		},
+		{
+			desc:     "begin with read write options and with Tx options",
+			withOpts: readWrite,
+			txOpts:   &sql.TxOptions{},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("failed to create sqlmock - %s", err)
+			}
+			gdb, err := gorm.Open("postgres", db)
+			if err != nil {
+				t.Fatalf("failed to open gorm db - %s", err)
+			}
+			dbReadOnly, dbROMock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("failed to create sqlmock - %s", err)
+			}
+			dbRO, err := gorm.Open("postgres", dbReadOnly)
+			if err != nil {
+				t.Fatalf("failed to open gorm read only db - %s", err)
+			}
+			mock.ExpectBegin()
+			dbROMock.ExpectBegin()
+			ctxtxn := &Transaction{parent: gdb, parentRO: dbRO}
+			ctx = NewContext(ctx, ctxtxn)
+			if test.txOpts == nil {
+				txn1, err := beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err != nil {
+					t.Error("Received an error beginning transaction")
+				}
+				if txn1 == nil {
+					t.Error("Did not receive a transaction from context")
+				}
+				test.withOpts = readOnly
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error DBOptionsMismatch")
+				}
+				test.withOpts = noOptions
+				txn3, err := beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err != nil {
+					t.Error("Received an error beginning transaction")
+				}
+				if txn3 == nil {
+					t.Error("Did not receive a transaction from context")
+				}
+				// Case: Transaction begin is idempotent
+				if txn1 != txn3 {
+					t.Error("Got a different txn than was opened before")
+				}
+			} else {
+				txn1, err := beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err != nil {
+					t.Error("Received an error beginning transaction")
+				}
+				if txn1 == nil {
+					t.Error("Did not receive a transaction from context")
+				}
+				test.txOpts.ReadOnly = true
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error TxOptionsMismatch")
+				}
+				test.txOpts.ReadOnly = false
+				test.txOpts.Isolation = sql.LevelSerializable
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error TxOptionsMismatch")
+				}
+				test.txOpts.Isolation = sql.LevelDefault
+				test.withOpts = readOnly
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error DBOptionsMismatch")
+				}
+				test.withOpts = noOptions
+				txn3, err := beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err != nil {
+					t.Error("Received an error beginning transaction")
+				}
+				if txn3 == nil {
+					t.Error("Did not receive a transaction from context")
+				}
+				// Case: Transaction begin is idempotent
+				if txn1 != txn3 {
+					t.Error("Got a different txn than was opened before")
+				}
+				test.txOpts.ReadOnly = true
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error TxOptionsMismatch")
+				}
+				test.txOpts.ReadOnly = false
+				test.txOpts.Isolation = sql.LevelSerializable
+				_, err = beginFromContextWithOptions(ctx, test.withOpts, test.txOpts)
+				if err == nil {
+					t.Error("begin transaction should fail with an error TxOptionsMismatch")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
This is to support read only database instance for performing read  operations on the database. Once these changes are approved and merged then all the modules can use this functionality to implement read only database support to perform database read operations in their project.