### PR TITLE
Add support for hooks which will run on transaction commit failure.

### DIFF
--- a/gorm/transaction.go
+++ b/gorm/transaction.go
@@ -60,9 +60,9 @@ type Transaction struct {
 	current         *gorm.DB
 	currentOpts     databaseOptions
 	afterCommitHook []func(context.Context)
-	// failedCommitHooks will run when error is occurred on transaction commit.
+	// afterFailedCommitHook will run when error is occurred on transaction commit.
 	// One of the use case of these hooks is to catch the error on transaction commit and convert it into a user-friendly message.
-	failedCommitHooks []func(context.Context, error) error
+	afterFailedCommitHook []func(context.Context, error) error
 }
 
 type databaseOptions struct {
@@ -105,8 +105,8 @@ func (t *Transaction) AddAfterCommitHook(hooks ...func(context.Context)) {
 	t.afterCommitHook = append(t.afterCommitHook, hooks...)
 }
 
-func (t *Transaction) AddFailedCommitHook(hooks ...func(context.Context, error) error) {
-	t.failedCommitHooks = append(t.failedCommitHooks, hooks...)
+func (t *Transaction) AddAfterFailedCommitHook(hooks ...func(context.Context, error) error) {
+	t.afterFailedCommitHook = append(t.afterFailedCommitHook, hooks...)
 }
 
 // getReadOnlyDBInstance returns current db txn if exists or the read only db txn if RO DB available otherwise it returns read/write db txn
@@ -298,8 +298,8 @@ func (t *Transaction) Commit(ctx context.Context) error {
 			t.afterCommitHook[i](ctx)
 		}
 	} else {
-		for i := range t.failedCommitHooks {
-			err = t.failedCommitHooks[i](ctx, err)
+		for i := range t.afterFailedCommitHook {
+			err = t.afterFailedCommitHook[i](ctx, err)
 		}
 	}
 	t.current = nil
@@ -326,7 +326,7 @@ func UnaryServerInterceptor(db *gorm.DB, readOnlyDB ...*gorm.DB) grpc.UnaryServe
 func UnaryServerInterceptorTxn(txn *Transaction) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
 		// Deep copy is necessary as a tansaction should be created per request.
-		txn := &Transaction{parent: txn.parent, parentRO: txn.parentRO, afterCommitHook: txn.afterCommitHook, failedCommitHooks: txn.failedCommitHooks}
+		txn := &Transaction{parent: txn.parent, parentRO: txn.parentRO, afterCommitHook: txn.afterCommitHook, afterFailedCommitHook: txn.afterFailedCommitHook}
 		defer func() {
 			// simple panic handler
 			if perr := recover(); perr != nil {

--- a/gorm/transaction_test.go
+++ b/gorm/transaction_test.go
@@ -367,6 +367,42 @@ func TestTransaction_AfterCommitHook(t *testing.T) {
 	}
 
 }
+
+func TestTransaction_AfterFailedCommitHook(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock - %s", err)
+	}
+	mock.ExpectBegin()
+	mock.ExpectCommit().WillReturnError(errors.New("failed to commit transaction due to some error"))
+
+	gdb, err := gorm.Open("postgres", db)
+	if err != nil {
+		t.Fatalf("failed to open gorm db - %s", err)
+	}
+	txn := &Transaction{parent: gdb}
+	txn.Begin()
+
+	called := false
+	hook := func(c context.Context, err error) error {
+		called = true
+		return err
+	}
+
+	txn.AddAfterFailedCommitHook(hook)
+	ctx := context.Background()
+
+	if err := txn.Commit(ctx); err != nil {
+		if !called {
+			t.Errorf("did not fire the hook")
+		}
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("failed to commit transaction - %s", err)
+	}
+}
+
 func TestTransaction_Rollback(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/gorm/transaction_test.go
+++ b/gorm/transaction_test.go
@@ -392,10 +392,12 @@ func TestTransaction_AfterFailedCommitHook(t *testing.T) {
 	txn.AddAfterFailedCommitHook(hook)
 	ctx := context.Background()
 
-	if err := txn.Commit(ctx); err != nil {
-		if !called {
-			t.Errorf("did not fire the hook")
-		}
+	if err = txn.Commit(ctx); err == nil {
+		t.Errorf("error is expected on this transaction commit.")
+	}
+
+	if !called {
+		t.Errorf("did not fire the hook")
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
Add support for hooks which should run on transaction commit failure.

Use case scenario: These hooks will be used to catch the error on db transaction commit and convert them into the user readable format.