### PR TITLE
[449] Fix overflow issue with math.MaxUint32 on 32-bit platforms

### DIFF
--- a/gateway/errors.go
+++ b/gateway/errors.go
@@ -209,7 +209,7 @@ var counter *uint32
 
 func init() {
 	counter = new(uint32)
-	*counter = uint32(time.Now().Nanosecond() % math.MaxUint32)
+	*counter = uint32(time.Now().Nanosecond()) % math.MaxUint32
 }
 
 // WithError will save an error message into the grpc trailer metadata, if it


### PR DESCRIPTION
Fix: 
Original expression used `math.MaxUint32` in a modulo operation against `int`,
which overflows on 32-bit systems. This change casts the value to `uint32`
before performing the modulo, making it safe for both 32-bit and 64-bit builds.