### PR TITLE
PTOPA-8965: cherry pick #434 on top of v0.25.4

### DIFF
--- a/query/sorting.go
+++ b/query/sorting.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -21,6 +22,11 @@ func (c SortCriteria) IsDesc() bool {
 func (c SortCriteria) GoString() string {
 	return fmt.Sprintf("%s %s", c.Tag, c.Order)
 }
+
+// FieldIdentifierRegex is a regular expression that matches valid field
+// identifiers. It is used to validate field names in sorting criteria. This can be
+// overridden at init() time to allow for custom field name formats.
+var FieldIdentifierRegex = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_\.]*$`)
 
 // ParseSorting parses raw string that represent sort criteria into a Sorting
 // data structure.
@@ -45,6 +51,14 @@ func ParseSorting(s string) (*Sorting, error) {
 			}
 		default:
 			return nil, fmt.Errorf("invalid sort criteria: %s", craw)
+		}
+		// check if tag is not valid
+		if !FieldIdentifierRegex.MatchString(c.Tag) {
+			return nil, fmt.Errorf("invalid field name: %s", c.Tag)
+		}
+		// check if tag is not empty
+		if c.Tag == "" {
+			return nil, fmt.Errorf("empty field name")
 		}
 
 		sorting.Criterias = append(sorting.Criterias, &c)

--- a/query/sorting_test.go
+++ b/query/sorting_test.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -57,5 +58,37 @@ func TestParseSorting(t *testing.T) {
 	}
 	if err.Error() != "invalid sort order - \"dask\" in \"name dask\"" {
 		t.Errorf("invalid error message: %s - expected: %s", err, "invalid sort order - \"dask\" in \"name dask\"")
+	}
+}
+
+func TestParseSortingInjection(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Sorting
+		wantErr bool
+	}{
+		{
+			name: "subquery",
+			args: args{
+				s: "(SELECT/**/1)::int",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSorting(tt.args.s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseSorting() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseSorting() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Applying the fix for sanitizing sorting on top of version tag v0.25.4

PS: Once merged we need to create a new tag and apply it to all the repo which is currently using version v0.25.4