### PR TITLE
Rearrange lock in Commit/Rollback to eliminate race condition (cherry-pick into v0.25 branch)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,11 +19,12 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.x"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
+            ${{ runner.os }}-go-${{ env.GITHUB_JOB }}-
             ${{ runner.os }}-go-
       - run: make test
       - name: uncommitted changes?


### PR DESCRIPTION
From master branch:
git cherry-pick 3d4bc44150134e27414f532f60dd8e0dbfd3eb59
git cherry-pick a0da2febfe1bac6a3ef08a67240eee74acc0b9ea

This fix is missing from v0.25 branch