### PR TITLE
Rearrange lock in Commit/Rollback to eliminate race condition (cherry-pick into v0.19 branch)

### DIFF
--- a/gorm/transaction.go
+++ b/gorm/transaction.go
@@ -133,15 +133,15 @@ func (t *Transaction) beginWithContextAndOptions(ctx context.Context, opts *sql.
 // Rollback terminates transaction by calling `*gorm.DB.Rollback()`
 // Reset current transaction and returns an error if any.
 func (t *Transaction) Rollback() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	if t.current == nil {
 		return nil
 	}
 	if reflect.ValueOf(t.current.CommonDB()).IsNil() {
 		return status.Error(codes.Unavailable, "Database connection not available")
 	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	t.current.Rollback()
 	err := t.current.Error
 	t.current = nil
@@ -151,11 +151,12 @@ func (t *Transaction) Rollback() error {
 // Commit finishes transaction by calling `*gorm.DB.Commit()`
 // Reset current transaction and returns an error if any.
 func (t *Transaction) Commit(ctx context.Context) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	if t.current == nil || reflect.ValueOf(t.current.CommonDB()).IsNil() {
 		return nil
 	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
 	t.current.Commit()
 	err := t.current.Error
 	if err == nil {


### PR DESCRIPTION
From master branch:
git cherry-pick 3d4bc44150134e27414f532f60dd8e0dbfd3eb59

There are many significant changes in fts-toolkit-1 that are not in v0.25:
https://github.com/infobloxopen/atlas-app-toolkit/compare/v0.25...fts-toolkit-1
so it was decided to officially maintain a v0.19 branch (off fts-toolkit-1) for the repos that are still using fts-toolkit-1/v0.19 branch (athena-identity-service, sso-identity-service, atlas.data.deletion)