### PR TITLE
fix: reject non-string JSON types in Identifier.UnmarshalJSONPB

### DIFF
--- a/rpc/resource/jsonpb.go
+++ b/rpc/resource/jsonpb.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/golang/protobuf/jsonpb"
@@ -35,12 +36,28 @@ var _ json.Marshaler = &Identifier{}
 //
 // Support "null" value.
 func (m *Identifier) UnmarshalJSONPB(_ *jsonpb.Unmarshaler, data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	// Identifier must be represented as a JSON string (quoted) or literal null.
+	// Reject arrays, objects, numbers, and booleans.
+	if data[0] != '"' && string(data) != "null" {
+		return fmt.Errorf("invalid value for resource identifier: expected a string, got: %s", truncateBytes(data, 64))
+	}
 	v := strings.Trim(string(data), "\"")
 	if v == "null" {
 		v = ""
 	}
 	m.ApplicationName, m.ResourceType, m.ResourceId = ParseString(v)
 	return nil
+}
+
+// truncateBytes returns the string representation of data, truncated to maxLen bytes.
+func truncateBytes(data []byte, maxLen int) string {
+	if len(data) <= maxLen {
+		return string(data)
+	}
+	return string(data[:maxLen]) + "..."
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface

--- a/rpc/resource/jsonpb_test.go
+++ b/rpc/resource/jsonpb_test.go
@@ -91,3 +91,87 @@ func TestIdentifier_UnmarhsalJSONPB(t *testing.T) {
 		}
 	}
 }
+
+func TestIdentifier_UnmarshalJSONPB_InvalidTypes(t *testing.T) {
+	tcases := []struct {
+		Name     string
+		JSONData string
+	}{
+		{"array", `["app/resource/id1","app/resource/id2"]`},
+		{"empty_array", `[]`},
+		{"number", `12345`},
+		{"negative_number", `-1`},
+		{"float_number", `1.5`},
+		{"object", `{"application_name":"app","resource_type":"res","resource_id":"id1"}`},
+		{"empty_object", `{}`},
+		{"boolean_true", `true`},
+		{"boolean_false", `false`},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			id := &Identifier{}
+			err := id.UnmarshalJSONPB(nil, []byte(tc.JSONData))
+			if err == nil {
+				t.Errorf("expected error for input %s, got nil", tc.JSONData)
+			}
+		})
+	}
+}
+
+func TestIdentifier_UnmarshalJSONPB_ValidInputs(t *testing.T) {
+	tcases := []struct {
+		Name               string
+		JSONData           string
+		ExpectedIdentifier *Identifier
+	}{
+		{
+			"valid resource identifier",
+			`"app/resource/res1"`,
+			&Identifier{ApplicationName: "app", ResourceType: "resource", ResourceId: "res1"},
+		},
+		{
+			"partial identifier with only resource id",
+			`"res1"`,
+			&Identifier{ApplicationName: "", ResourceType: "", ResourceId: "res1"},
+		},
+		{
+			"partial identifier with type and id",
+			`"resource/res1"`,
+			&Identifier{ApplicationName: "", ResourceType: "resource", ResourceId: "res1"},
+		},
+		{
+			"null literal",
+			`null`,
+			&Identifier{ApplicationName: "", ResourceType: "", ResourceId: ""},
+		},
+		{
+			"quoted null",
+			`"null"`,
+			&Identifier{ApplicationName: "", ResourceType: "", ResourceId: ""},
+		},
+		{
+			"empty string",
+			`""`,
+			&Identifier{ApplicationName: "", ResourceType: "", ResourceId: ""},
+		},
+		{
+			"empty data",
+			``,
+			&Identifier{ApplicationName: "", ResourceType: "", ResourceId: ""},
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			id := &Identifier{}
+			err := id.UnmarshalJSONPB(nil, []byte(tc.JSONData))
+			if err != nil {
+				t.Errorf("unexpected error for input %s: %s", tc.JSONData, err)
+			}
+			if id.String() != tc.ExpectedIdentifier.String() {
+				t.Errorf("got %s, expected %s", id, tc.ExpectedIdentifier)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Identifier.UnmarshalJSONPB previously accepted any JSON type (arrays, numbers, objects, booleans) without returning an error, producing garbage field values. This caused downstream UUID parsing failures that surfaced as 500 Internal Server Errors instead of 400 Bad Request.

Now validates that input is a JSON string or null before parsing. Returns a clear error for invalid types.